### PR TITLE
Fix: no empty arrays are allowed on RuleActionOverrides

### DIFF
--- a/lib/firewall-stack.ts
+++ b/lib/firewall-stack.ts
@@ -414,7 +414,7 @@ function buildServiceDataManagedRGs(managedRuleGroups: ManagedRuleGroup[]) : Ser
       ruleGroupArn: null,
       excludeRules: managedRuleGroup.ExcludeRules ?  toAwsCamel(managedRuleGroup.ExcludeRules) : [],
       ruleGroupType: "ManagedRuleGroup",
-      ruleActionOverrides: managedRuleGroup.RuleActionOverrides ?  managedRuleGroup.RuleActionOverrides : [],
+      ruleActionOverrides: managedRuleGroup.RuleActionOverrides ?  managedRuleGroup.RuleActionOverrides : undefined,
     });
     let version ="";
     if(managedRuleGroup.Version !== ""){

--- a/lib/types/fms.ts
+++ b/lib/types/fms.ts
@@ -69,7 +69,7 @@ export interface ServiceDataManagedRuleGroup extends ServiceDataAbstactRuleGroup
           Count: {}
         }
       }
-  ] | [],
+  ] | undefined,
 }
 
 export interface ServiceDataRuleGroup extends ServiceDataAbstactRuleGroup {


### PR DESCRIPTION
Hi!

While deploying the repo to a account yesterday I encountered a CloudFormation error saying something like `RuleActionOverrides can't be a empty array, at least one item is expected`. It happened because I haven't specified any "RuleActionOverrides" in my JSON.

This PR fixes it, it's already tested.