### PR TITLE
Fix: invalid pattern

### DIFF
--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -14,7 +14,7 @@ export interface Config {
   readonly WebAcl:{
     readonly Name: string,
     /**
-      * @TJS-pattern "^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$"
+      * @TJS-pattern ^([\p{L}\p{Z}\p{N}_.:\/=+\-@]*)$
     */
     readonly Description?: string,
     readonly IncludeMap:  fms.CfnPolicy.IEMapProperty,


### PR DESCRIPTION
The pattern for the WebAcl description was invalid, I fixed it by removing the quotes around it and escaping the `/` char. I've tested it and now it's working.