### PR TITLE
Fix: Allow many rule action overrides

### DIFF
--- a/lib/types/fms.ts
+++ b/lib/types/fms.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
+type RuleActionOverrideProperty = { Name: string, ActionToUse: { Count: {} }}
 export interface ManagedRuleGroup {
   Vendor: string,
   Name: string,
@@ -8,15 +9,7 @@ export interface ManagedRuleGroup {
   OverrideAction?: {
     type: "COUNT" | "NONE"
   },
-  RuleActionOverrides?: [
-    {
-      Name: string,
-      ActionToUse:
-      {
-        Count: {}
-      }
-    }
-  ]
+  RuleActionOverrides?: RuleActionOverrideProperty[] | undefined
 }
 
 export interface Rule {
@@ -61,15 +54,7 @@ export interface ServiceDataManagedRuleGroup extends ServiceDataAbstactRuleGroup
   },
   excludeRules: any,
   ruleGroupType: "ManagedRuleGroup",
-  ruleActionOverrides: [
-      {
-        Name: string,
-        ActionToUse:
-        {
-          Count: {}
-        }
-      }
-  ] | undefined,
+  ruleActionOverrides: RuleActionOverrideProperty[] | undefined,
 }
 
 export interface ServiceDataRuleGroup extends ServiceDataAbstactRuleGroup {


### PR DESCRIPTION
As it was before, the RuleActionOverrides array allowed only one item. When I've tried deploying many overrides under RuleActionOverrides it failed with `must NOT have more than 1 items`. This commit fixes it.

It still needs improvement, as the `RuleActionOverrides[].ActionToUse` could have the `Count` prop, `Allow` and many others. This is the docs for the type: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_wafv2.CfnWebACL.RuleActionOverrideProperty.html

I tried importing the type directly from the cdk, but the `values/*.json` files have a camel case definition, with the first char being uppercased, while in the CDK they are undercased. I didn't want to mix two different patterns, and I got to lazy to define everything manually. I also don't know a solution for importing types from the CDK but transforming them to be uppercased on the first char.

Anyway, here's the PR.