### PR TITLE
Fix: allow many rule action overrides

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,7 +59,7 @@ tasks:
     desc: CDK Deploy
     cmds:
       - cdk deploy --require-approval never {{.TAGS}}
-      - rm -f $(find ./cdk.out/*assets.json -type f)
+      - rm -f $(find ./cdk.out/*assets.json -type f) &> /dev/null
     vars:
       ACCOUNT:
         sh: aws sts get-caller-identity |jq -r .Account

--- a/lib/firewall-stack.ts
+++ b/lib/firewall-stack.ts
@@ -415,7 +415,7 @@ function buildServiceDataManagedRGs(managedRuleGroups: ManagedRuleGroup[]) : Ser
       ruleGroupArn: null,
       excludeRules: managedRuleGroup.ExcludeRules ?  toAwsCamel(managedRuleGroup.ExcludeRules) : [],
       ruleGroupType: "ManagedRuleGroup",
-      ruleActionOverrides: managedRuleGroup.RuleActionOverrides ?  managedRuleGroup.RuleActionOverrides : undefined,
+      ruleActionOverrides: managedRuleGroup.RuleActionOverrides ?  toAwsCamel(managedRuleGroup.RuleActionOverrides) : undefined,
     });
     let version ="";
     if(managedRuleGroup.Version !== ""){

--- a/lib/types/fms.ts
+++ b/lib/types/fms.ts
@@ -1,4 +1,14 @@
 /* eslint-disable @typescript-eslint/ban-types */
+interface RuleActionOverrideProperty {
+  Name: string, 
+  ActionToUse: {
+    "Allow"?: {},
+    "Block"?: {},
+    "Count"?: {},
+    "Captcha"?: {},
+    "Challenge"?: {}
+  }
+}
 export interface ManagedRuleGroup {
   Vendor: string,
   Name: string,
@@ -8,15 +18,7 @@ export interface ManagedRuleGroup {
   OverrideAction?: {
     type: "COUNT" | "NONE"
   },
-  RuleActionOverrides?: [
-    {
-      Name: string,
-      ActionToUse:
-      {
-        Count: {}
-      }
-    }
-  ]
+  RuleActionOverrides?: RuleActionOverrideProperty[] | undefined
 }
 
 export interface Rule {
@@ -61,15 +63,7 @@ export interface ServiceDataManagedRuleGroup extends ServiceDataAbstactRuleGroup
   },
   excludeRules: any,
   ruleGroupType: "ManagedRuleGroup",
-  ruleActionOverrides: [
-      {
-        Name: string,
-        ActionToUse:
-        {
-          Count: {}
-        }
-      }
-  ] | undefined,
+  ruleActionOverrides: RuleActionOverrideProperty[] | undefined,
 }
 
 export interface ServiceDataRuleGroup extends ServiceDataAbstactRuleGroup {

--- a/values/RuleActionOverrides.json
+++ b/values/RuleActionOverrides.json
@@ -1,0 +1,49 @@
+{
+  "General": {
+    "Prefix": "",
+    "Stage": "",
+    "S3LoggingBucketName": "",
+    "CreateDashboard": true,
+    "DeployHash": "",
+    "FireHoseKeyArn": "",
+    "SecuredDomain": []
+  },
+  "WebAcl": {
+    "Name": "Test",
+    "Scope": "REGIONAL",
+    "Description": "",
+    "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    "RemediationEnabled": true,
+    "ResourcesCleanUp": true,
+    "IncludeMap": {
+      "account": [
+        ""
+      ]
+    },
+    "PreProcess": {},
+    "PostProcess": {
+      "ManagedRuleGroups": [
+        {
+          "Vendor": "AWS",
+          "Name": "AWSManagedRulesAnonymousIpList",
+          "Version": "",
+          "Capacity": 50,
+          "RuleActionOverrides": [
+            {
+              "Name": "AnonymousIPList",
+              "ActionToUse": {
+                "Count": {}
+              }
+            },
+            {
+              "Name": "HostingProviderIPList",
+              "ActionToUse": {
+                "Allow": {}
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Hi!

This PR implements two needed fixes and one eye candy modification:

* `Error message might confuse people`: This is just for eye candy and for helping newcomers. The first time I ran the repo I saw it and it scared me a bit. :)
* `Fix: AWS only accepts RuleActionOverrides in camelCase`: this commit was what allowed me to specify RuleActionOverrides, without it CloudFormation would throw a weird error.
* `Allow all types of OverrideActions`: This is for the future, if people wants to implement RuleActionOverrides other then "Count" now they can.

Wish you a great weekend! ^^