### PR TITLE
Fix: allow sub-statements of IPSetReferenceStatements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-firewall-factory",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-firewall-factory",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.353.0",
         "@aws-sdk/client-cloudwatch": "^3.353.0",


### PR DESCRIPTION
Hi!

This PR is for allowing `IPSetReferenceStatement.ARN` entries which references a aws-firewall-factory controlled ipset (i.e. the name of the ipset) inside AND, OR and NOT statements (as sub-statements).

Before this PR, this policy would fail:
```
{
  "Name": "only-allow-the-good-guys",
  "Statement": {
    "AndStatement": {
      "Statements": [
        {
          "ByteMatchStatement": {
            "SearchString": "/good/guys/entrypoint",
            "FieldToMatch": {
              "UriPath": {}
            },
            "TextTransformations": [
              {
                "Priority": 0,
                "Type": "NONE"
              }
            ],
            "PositionalConstraint": "STARTS_WITH"
          }
        },
        {
          "NotStatement": {
            "Statement": {
              "IPSetReferenceStatement": {
                "ARN": "GoodGuysIPs"
              }
            }
          }
        }
      ]
    }
  },
  "Action": {
    "Block": {}
  },
  "VisibilityConfig": {
    "SampledRequestsEnabled": true,
    "CloudWatchMetricsEnabled": true
  }
}
```

Now its working ^^