### PR TITLE
Update aws-firewall-factory 4.1.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,36 +7,40 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking"
+    "plugin:@typescript-eslint/recommended"
   ],
-  "parserOptions": {
-    "project": true
-  },
   "rules": {
-    "semi": ["error", "always"],
-    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "semi": [2, "always"],
+    "eqeqeq": 2,
+    "indent": [2, 2, {"SwitchCase": 1}],
     "quotes": ["error", "double"],
-    "@typescript-eslint/naming-convention": [
-      "error",
-      {
-        "selector": ["variableLike", "method"],
-        "format": ["strictCamelCase"]
-      },
-      {
-        "selector": ["variable"],
-        "format": ["UPPER_CASE"],
-        "modifiers": ["const","global"],
-        "types": ["array", "boolean", "number", "string"]
-      },
-      {
-        "selector": ["class","interface","enum", "typeParameter", "typeAlias"],
-        "format": ["StrictPascalCase"]
-      },
-      {
-        "selector": ["enumMember"],
-        "format": ["UPPER_CASE"]
-      }
-    ]
+    "linebreak-style": "off",
+    "array-bracket-newline": "off",
+    "array-bracket-spacing": ["error", "never"],
+    "no-trailing-spaces": "off",
+    "padded-blocks": "off",
+    "arrow-body-style": "off",
+    "init-declarations": "off",
+    "comma-dangle": "off",
+    "keyword-spacing": [0, {"before": true, "after": true, "overrides": null}],
+    "prefer-template": "off",
+    "id-blacklist": "off",
+    "no-console": "off",
+    "no-sync": "off",
+    "complexity": "off",
+    "max-statements": "off",
+    "array-element-newline": "off",
+    "object-curly-spacing": "off",
+    "template-curly-spacing": "off",
+    "camelcase": "off",
+    "no-use-before-define": "off",
+    "id-length": "off",
+    "id-match": "off",
+    "max-len": "off",
+    "no-magic-numbers": "off",
+    "no-underscore-dangle": "off",
+    "no-process-env": "off",
+    "func-style": ["error", "declaration", { "allowArrowFunctions": true }],
+    "no-useless-escape": "off"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,27 @@
 # Change Log
 
 ## Released
+## 4.1.0
 
+### Added
+- This update presents a new feature that centralizes the management of RegexPatternSet. With this improvement, manual updates of regexpatternset across multiple AWS accounts are no longer necessary.
+  Users can now define the feature in code and replicate it for use by WAF rules wherever applicable.
+- Additionally, cdk destroy has been included in the taskfile.
+- Furthermore, we have modified several enums to enhance their ease of with previous versions: use while maintaining downward compatibility, such as
+  - WebAclScope
+  - AwsManagedRules
+  - ManagedRuleGroupVendor
+  - CustomResponseBodiesContentType
+  - WebAclTypeEnum
+- uuidFirewallFactoryResourceIdentitfier: Introducing a firewall identifier UUID that will be utilized for resource names in AWS.
+
+### Fixed
+- Capacity and version information for Managed Rule Groups are now optional. We calculate the capacity on the fly, so specifying capacity is unnecessary. If no version is provided, we will retrieve the latest version for the Managed Rule Group using the API.
+- DeliveryStreamName not checked - Erroneous if exceeding 64 character limit [source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisfirehose-deliverystream.html#cfn-kinesisfirehose-deliverystream-deliverystreamname).
+- Fixed nonfunctional documentation links.
+
+### Removed
+- Export names from CloudFormation stack outputs, as we rely on the stack name and output names from the particular CloudFormation stack to obtain the necessary information.
 ## 4.0.0
 ### Added
 - A custom resource to retrieve the latest version of the ManagedRuleGroup and check if the specified version is valid.

--- a/Deployment.md
+++ b/Deployment.md
@@ -1,0 +1,34 @@
+## 🛡️ Deployment
+
+### ⚙️ Prerequisites
+1. [Organizations trusted access with Firewall Manager](https://docs.aws.amazon.com/organizations/latest/userguide/services-that-can-integrate-fms.html)
+2. [Taskfile](https://taskfile.dev/)
+3. [AWS CDK](https://aws.amazon.com/cdk/)
+4. [cfn-dia](https://www.npmjs.com/package/@mhlabs/cfn-diagram?s=03)
+5. Invoke `npm i` to install dependencies
+6. ⚠️ Before installing a stack to your aws account using aws cdk you need to prepare the account using a [cdk bootstrap](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html)
+
+7. (Optional) If you want to use CloudWatch Dashboards - You need to enable your target accounts to share CloudWatch data with the central security account follow [this](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Cross-Account-Cross-Region.html#enable-cross-account-cross-Region) to see how to do it.
+8. Assume AWS Profile `awsume PROFILENAME`
+9. (Optional) Enter `task generateprerequisitesconfig`
+
+  | Parameter  | Value |
+  | ------------- | ------------- |
+  | Prefix  | Prefix for all Resources  |
+  | BucketName [^1] | Name of the S3 Bucket |
+  | KmsEncryptionKey | true or false  |
+  | ObjectLock - Days [^1]| A period of Days for ObjectLock |
+  | ObjectLock - Mode [^1]| COMPLIANCE or GOVERNANCE |
+  | FireHoseKey - KeyAlias [^1] | Alias for Key |
+  | CrossAccountIdforPermissions [^1] | Id of AWS Account for CrossAccount Permission for Bucket and KMS Key(s)|
+
+10. Enter `task deploy config=NAMEOFYOURCONFIGFILE prerequisite=true`
+
+
+### 🏁 Deployment via Taskfile
+
+1. Create new ts file for you WAF and configure Rules in the Configuration (see [owasptopten.ts](values/examples/owasptop10.ts) to see structure) or use enter `task generate-waf-skeleton`
+
+2. Assume AWS Profile `awsume / assume PROFILENAME`
+3. (Optional) Enter `task generate-waf-skeleton`
+4. Enter `task deploy config=NAMEOFYOURCONFIGFILE`

--- a/Features.md
+++ b/Features.md
@@ -1,0 +1,80 @@
+## 🧩 Features
+
+1. Automated capactiy calculation via [API - CheckCapacity](https://docs.aws.amazon.com/waf/latest/APIReference/API_CheckCapacity.html)
+
+2. Algorithm to split Rules into RuleGroups
+
+3. Automated update of RuleGroup if capacity changed
+
+4. Add [ManagedRuleGroups](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html) via configuration file
+
+5. Automated generation of draw.io [diagram](https://app.diagrams.net/) for each WAF
+
+6. Checking of the softlimit quota for [WCU](https://docs.aws.amazon.com/waf/latest/developerguide/how-aws-waf-works.html) set in the AWS account (stop deployment if calculated WCU is above the quota)
+
+7. Easy configuration of WAF rules trough Typescript file.
+   
+8. Deploy same WAF more than once for testing and/or blue/green deployments.
+
+9.  Stopping deployment if soft limit will be exceeded:  **Firewall Manager policies per organization per Region (L-0B28E140)** - **Maximum number of web ACL capacity units in a web ACL in WAF for regional (L-D9F31E8A)**
+
+10. You can name your rules. If you define a name in your RulesArray, the name + a Base36 timestamp will be used for the creation of your rule - otherwise a name will be generated. This will help you to query your logs in Athena.
+
+11. Support for Captcha - You can add Captcha as an action to your WAFs. This helps you block unwanted bot traffic by requiring users to successfully complete challenges before their web request are allowed to reach AWS WAF protected resources. AWS WAF Captcha is available in the US East (N. Virginia), US West (Oregon), Europe (Frankfurt), South America (Sao Paulo), and Asia Pacific (Singapore) AWS Regions and supports Application Load Balancer, Amazon API Gateway, and AWS AppSync resources.
+
+12. Added S3LoggingBucketName to Configuration. You need to specify the S3 Bucket where logs should be placed in. We also added a prefix for the logs to be AWS conform (Prefix: AWSLogs/*AWS_ACCOUNTID*/FirewallManager/*AWS_REGION*/).
+
+13. Added testing your WAF with [GoTestWAF](https://github.com/wallarm/gotestwaf). To be able to check your WAF we introduced the **SecuredDomain** parameter in the Configuration (which should be your domain) which will be checked using the WAF tool.
+
+14. TaskFileParameters:
+
+    |     Parameter      |                                           Value                                              |
+    |--------------------|----------------------------------------------------------------------------------------------|
+    | SKIP_QUOTA_CHECK   | true (Stop deployment if calculated WCU is above the quota) </br> false (Skipping WCU Check) |
+    | WAF_TEST           | true (testing your waf with GoTestWAF) </br> false (Skipping WAF testing)                    |
+    | CREATE_DIAGRAM     | true (generating a diagram using draw.io) </br> false (Skipping diagram generation)          |
+    | PREQUISITES        | true (deploys Prerequisites Stack) </br> false (deployment of WAF)           |
+    | TOOL_KIT_STACKNAME        | To Specify The name of the bootstrap stack ([see Bootstrapping your AWS environment](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-bootstrap))       |
+
+15. Validation of your ConfigFile using schema validation - if you miss a required parameter in your config file the deployment will stop automatically and show you the missing path.
+
+16. PreProcess- and PostProcessRuleGroups - you can decide now where the Custom or ManagedRules should be added to.
+
+    - New Structure see [example Configuration](./values/examples).
+
+17. RuleLabels - A label is a string made up of a prefix, optional namespaces and a name. The components of a label are delimited with a colon. Labels have the following requirements and characteristics:
+
+    - Labels are case-sensitive.
+
+    - Each label namespace or label name can have up to 128 characters.
+
+    - You can specify up to five namespaces in a label.
+
+    - Components of a label are separated by a colon ( : ).
+
+18. While Deployment the Price for your WAF will be calculated using the Pricing API
+
+19. Dashboard - The Firewall Factory is able to provision a CloudWatch Dashboard per Firewall.
+  The Dashboard shows:
+    - Where the WAF is deployed to [AWS Region and Account(s)]
+    - Which resource type you are securing
+    - Which Managed Rule Groups in which version are in use
+    - Link to Managed Rule Groups documentation
+    - Direct Link to your secured Application / Endpoint
+    - AWS Firewall Factory version
+    - Check if the AWS Firewall Factory version is the latest or not during rollout
+    - Allowed / Blocked and Counted Requests
+    - Bot vs Non-bot Requests
+
+See example:
+![FirewallDashboard](./static/FirewallDashboard.jpg)
+
+20. Example Configurations
+    1.  Example WAF Configuration againts: [OWASP Top Ten](https://owasp.org/www-project-top-ten/)
+    2.  Example Configuration for Prerequisite Stack
+    3.  Function to generate Skeleton for WAF Configuration
+
+21.   Centralized IPSets management -  No more we'll have to be manually updating ipsets across multiple AWS accounts, it can be defined in code and replicated for use by WAF rules everywhere its needed. Check the examples for defining ipsets and using them in the WebACLs on `values/examples/ip-sets-managed-test.ts`.
+
+22. Centralized management of RegexPatternSets - No longer will there be a need for manual updates of RegexPatternSets across multiple AWS accounts. These can now be defined in code and replicated for use by WAF rules wherever needed.
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 
-<a href="https://github.com/globaldatanet/aws-firewall-factory/actions/workflows/linting.yml"><img alt="github-badge" src="https://github.com/globaldatanet/aws-firewall-factory/actions/workflows/linting.yml/badge.svg"></a>
 [![Mentioned in Awesome CDK](https://awesome.re/mentioned-badge.svg)](https://github.com/kolomied/awesome-cdk)
 [![License: Apache2](https://img.shields.io/badge/license-Apache%202-lightgrey.svg)](http://www.apache.org/licenses/) [![cdk](https://img.shields.io/badge/aws_cdk-v2-orange.svg)](https://docs.aws.amazon.com/cdk/v2/guide/home.html)
 [![latest](https://img.shields.io/badge/latest-release-yellow.svg)](https://github.com/globaldatanet/aws-firewall-factory/releases)
@@ -7,6 +6,7 @@
 [![TypeScript](https://badges.frapsoft.com/typescript/love/typescript.png?v=101)](https://github.com/ellerbrock/typescript-badges/)
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=AWS%20FIREWALL%20FACTORY%20-%20Deploy%2C%20update%2C%20and%20stage%20your%20WAFs%20while%20managing%20them%20centrally%20via%20FMS&url=https://github.com/globaldatanet/aws-firewall-factory&hashtags=aws,security,waf)
 [![roadmap](https://img.shields.io/badge/public-roadmap-yellow.svg)](https://github.com/orgs/globaldatanet/projects/1)
+
 
 **[🚧 Feature request](https://github.com/globaldatanet/aws-firewall-factory/issues/new?assignees=&labels=feature-request%2C+enhancement&template=feature_request.md&title=)** | **[🐛 Bug Report](https://github.com/globaldatanet/aws-firewall-factory/issues/new?assignees=&labels=bug%2C+triage&template=bug_report.md&title=)**
 
@@ -19,19 +19,13 @@
 - [🎬 Media](#-media)
     - [🔗 Useful Links](#-useful-links)
 - [🗺️ Architecture](#️-architecture)
-- [🧩 Features](#-features)
-- [🛡️ Deployment](#️-deployment)
-  - [⚙️ Prerequisites](#️-prerequisites)
-  - [🏁 Deployment via Taskfile](#-deployment-via-taskfile)
 - [🦸🏼‍♀️ Contributors](#️-contributors)
   - [👩‍💻 Contribute](#-contribute)
   - [👏 Supporters](#-supporters)
 
-</br>
-
 |                     Releases                      | Author |
 |---------------------------------------------------|--------|
-| [Changelog](CHANGELOG.md) - [Features](#Features) | David Krohn </br> [Linkedin](https://www.linkedin.com/in/daknhh/) - [Blog](https://globaldatanet.com/our-team/david-krohn)|
+| [Changelog](CHANGELOG.md) - [Features](Features.md) - [🛡️ Deployment](Deployment.md) | David Krohn </br> [Linkedin](https://www.linkedin.com/in/daknhh/) - [Blog](https://globaldatanet.com/our-team/david-krohn)|
 
 </br>
 
@@ -63,138 +57,6 @@ If you want to learn more about the AWS Firewall Factory feel free to look at th
 ## 🗺️ Architecture
 
 ![Architecture](./static/AWSFIREWALLMANAGER.png "Architecture")
-
-
-<details>
-    <summary> Features</summary>
-   <div>
-
-## 🧩 Features
-
-1. Automated capactiy calculation via [API - CheckCapacity](https://docs.aws.amazon.com/waf/latest/APIReference/API_CheckCapacity.html)
-
-2. Algorithm to split Rules into RuleGroups
-
-3. Automated update of RuleGroup if capacity changed
-
-4. Add [ManagedRuleGroups](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html) via configuration file
-
-5. Automated generation of draw.io [diagram](https://app.diagrams.net/) for each WAF
-
-6. Checking of the softlimit quota for [WCU](https://docs.aws.amazon.com/waf/latest/developerguide/how-aws-waf-works.html) set in the AWS account (stop deployment if calculated WCU is above the quota)
-
-7. Easy configuration of WAF rules trough Typescript file.
-   
-8. Deploy same WAF more than once for testing and/or blue/green deployments.
-
-9.  Stopping deployment if soft limit will be exceeded:  **Firewall Manager policies per organization per Region (L-0B28E140)** - **Maximum number of web ACL capacity units in a web ACL in WAF for regional (L-D9F31E8A)**
-
-10. You can name your rules. If you define a name in your RulesArray, the name + a Base36 timestamp will be used for the creation of your rule - otherwise a name will be generated. This will help you to query your logs in Athena.
-
-11. Support for Captcha - You can add Captcha as an action to your WAFs. This helps you block unwanted bot traffic by requiring users to successfully complete challenges before their web request are allowed to reach AWS WAF protected resources. AWS WAF Captcha is available in the US East (N. Virginia), US West (Oregon), Europe (Frankfurt), South America (Sao Paulo), and Asia Pacific (Singapore) AWS Regions and supports Application Load Balancer, Amazon API Gateway, and AWS AppSync resources.
-
-12. Added S3LoggingBucketName to Configuration. You need to specify the S3 Bucket where logs should be placed in. We also added a prefix for the logs to be AWS conform (Prefix: AWSLogs/*AWS_ACCOUNTID*/FirewallManager/*AWS_REGION*/).
-
-13. Added testing your WAF with [GoTestWAF](https://github.com/wallarm/gotestwaf). To be able to check your WAF we introduced the **SecuredDomain** parameter in the Configuration (which should be your domain) which will be checked using the WAF tool.
-
-14. TaskFileParameters:
-
-    |     Parameter      |                                           Value                                              |
-    |--------------------|----------------------------------------------------------------------------------------------|
-    | SKIP_QUOTA_CHECK   | true (Stop deployment if calculated WCU is above the quota) </br> false (Skipping WCU Check) |
-    | WAF_TEST           | true (testing your waf with GoTestWAF) </br> false (Skipping WAF testing)                    |
-    | CREATE_DIAGRAM     | true (generating a diagram using draw.io) </br> false (Skipping diagram generation)          |
-    | PREQUISITES        | true (deploys Prerequisites Stack) </br> false (deployment of WAF)           |
-    | TOOL_KIT_STACKNAME        | To Specify The name of the bootstrap stack ([see Bootstrapping your AWS environment](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-bootstrap))       |
-
-15. Validation of your ConfigFile using schema validation - if you miss a required parameter in your config file the deployment will stop automatically and show you the missing path.
-
-16. PreProcess- and PostProcessRuleGroups - you can decide now where the Custom or ManagedRules should be added to.
-
-    - New Structure see [example Configuration](./values/examples).
-
-17. RuleLabels - A label is a string made up of a prefix, optional namespaces and a name. The components of a label are delimited with a colon. Labels have the following requirements and characteristics:
-
-    - Labels are case-sensitive.
-
-    - Each label namespace or label name can have up to 128 characters.
-
-    - You can specify up to five namespaces in a label.
-
-    - Components of a label are separated by a colon ( : ).
-
-18. While Deployment the Price for your WAF will be calculated using the Pricing API
-
-19. Dashboard - The Firewall Factory is able to provision a CloudWatch Dashboard per Firewall.
-  The Dashboard shows:
-    - Where the WAF is deployed to [AWS Region and Account(s)]
-    - Which resource type you are securing
-    - Which Managed Rule Groups in which version are in use
-    - Link to Managed Rule Groups documentation
-    - Direct Link to your secured Application / Endpoint
-    - AWS Firewall Factory version
-    - Check if the AWS Firewall Factory version is the latest or not during rollout
-    - Allowed / Blocked and Counted Requests
-    - Bot vs Non-bot Requests
-
-See example:
-![FirewallDashboard](./static/FirewallDashboard.jpg)
-
-20. Example Configurations
-    1.  Example WAF Configuration againts: [OWASP Top Ten](https://owasp.org/www-project-top-ten/)
-    2.  Example Configuration for Prerequisite Stack
-    3.  Function to generate Skeleton for WAF Configuration
-
-21.   Centralized IPSets management -  No more we'll have to be manually updating ipsets across multiple AWS accounts, it can be defined in code and replicated for use by WAF rules everywhere its needed. Check the examples for defining ipsets and using them in the WebACLs on `values/examples/ip-sets-managed-test.ts`.
-
-</div>
-</details>
-
-
-## 🛡️ Deployment
-
-<details>
-    <summary> Prerequisites</summary>
-   <div>
-
-### ⚙️ Prerequisites
-1. [Organizations trusted access with Firewall Manager](https://docs.aws.amazon.com/organizations/latest/userguide/services-that-can-integrate-fms.html)
-2. [Taskfile](https://taskfile.dev/)
-3. [AWS CDK](https://aws.amazon.com/cdk/)
-4. [cfn-dia](https://www.npmjs.com/package/@mhlabs/cfn-diagram?s=03)
-5. Invoke `npm i` to install dependencies
-6. ⚠️ Before installing a stack to your aws account using aws cdk you need to prepare the account using a [cdk bootstrap](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html)
-
-7. (Optional) If you want to use CloudWatch Dashboards - You need to enable your target accounts to share CloudWatch data with the central security account follow [this](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Cross-Account-Cross-Region.html#enable-cross-account-cross-Region) to see how to do it.
-8. Assume AWS Profile `awsume PROFILENAME`
-9. (Optional) Enter `task generateprerequisitesconfig`
-
-  | Parameter  | Value |
-  | ------------- | ------------- |
-  | Prefix  | Prefix for all Resources  |
-  | BucketName [^1] | Name of the S3 Bucket |
-  | KmsEncryptionKey | true or false  |
-  | ObjectLock - Days [^1]| A period of Days for ObjectLock |
-  | ObjectLock - Mode [^1]| COMPLIANCE or GOVERNANCE |
-  | FireHoseKey - KeyAlias [^1] | Alias for Key |
-  | CrossAccountIdforPermissions [^1] | Id of AWS Account for CrossAccount Permission for Bucket and KMS Key(s)|
-
-10. Enter `task deploy config=NAMEOFYOURCONFIGFILE prerequisite=true`
-
-</div>
-</details>
-
-<details>
-    <summary> Deployment via Taskfile </summary>
-   <div>
-
-### 🏁 Deployment via Taskfile
-
-1. Create new ts file for you WAF and configure Rules in the Configuration (see [owasptopten.ts](values/examples/owasptop10.ts) to see structure) or use enter `task generate-waf-skeleton`
-
-2. Assume AWS Profile `awsume / assume PROFILENAME`
-3. (Optional) Enter `task generate-waf-skeleton`
-4. Enter `task deploy config=NAMEOFYOURCONFIGFILE`
 
 ## 🦸🏼‍♀️ Contributors
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,6 +15,10 @@ vars:
   CDK_DEFAULT_ACCOUNT:
     sh: aws sts get-caller-identity |jq -r .
 tasks:
+  destroy:
+    desc: Destroy Stack
+    cmds:
+      - task: cdkdestroy
   deploy:
     desc: Deploy Stack
     cmds:
@@ -40,6 +44,18 @@ tasks:
     env:
       PROCESS_PARAMETERS: "{{.config}}"
       PREREQUISITE: "{{.prerequisite}}"
+  cdkdestroy:
+    desc: CDK Destroy
+    cmds:
+      - cdk destroy
+    vars:
+      ACCOUNT:
+        sh: aws sts get-caller-identity |jq -r .Account
+    env:
+      PROCESS_PARAMETERS: "{{.config}}"
+      PREREQUISITE: "{{.prerequisite}}"
+    silent: true
+    interactive: true
   cdkdeploy:
     desc: CDK Deploy
     cmds:

--- a/bin/aws-firewall-factory.ts
+++ b/bin/aws-firewall-factory.ts
@@ -93,6 +93,13 @@ void (async () => {
         console.log("      ⚙️  [" + ipSet.ipAddressVersion + "] | 🌎 [" + config.WebAcl.Scope+ "]");
       }
     }
+    if(Array.isArray(config.WebAcl.RegexPatternSets) &&  config.WebAcl.RegexPatternSets.length > 0) {
+      console.log("\n𝍂 RegexPatternSets");
+      for(const regpatternset of config.WebAcl.RegexPatternSets) {
+        console.log("   ➕ " + regpatternset.name);
+        console.log("      ⚙️ 🌎 [" + config.WebAcl.Scope+ "]");
+      }
+    }
     const wcuQuotaReached = await isWcuQuotaReached(deploymentRegion, runtimeProperties, config);
     if(wcuQuotaReached) {
       console.error("\u001B[31m","🚨 ERROR: Exit process due Quota Check for WCU 🚨 \n\n","\x1b[0m" + "\n\n");

--- a/lib/lambda/ManagedRuleGroupVersion/index.ts
+++ b/lib/lambda/ManagedRuleGroupVersion/index.ts
@@ -4,20 +4,18 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {
   CdkCustomResourceEvent,
-  CdkCustomResourceResponse,
-  Context,
+  CdkCustomResourceResponse
 } from "aws-lambda";
 import { getManagedRuleGroupVersion } from "./services/waf";
 import {ManagedRuleGroupVersionResponse} from "./types/index";
 
 export const handler = async (
-  event: CdkCustomResourceEvent,
-  context: Context,
+  event: CdkCustomResourceEvent
 ): Promise<CdkCustomResourceResponse> => {
   let ManagedVersionInfo: ManagedRuleGroupVersionResponse;
   let ParamVersion: string | undefined;
   let Latest: boolean | undefined;
-  console.log("Lambda is invoked with:" + JSON.stringify(event) +"-"+ JSON.stringify(context));
+  console.log("Lambda is invoked with:" + JSON.stringify(event));
   
   const response: CdkCustomResourceResponse = {
     StackId: event.StackId,

--- a/lib/tools/generate-skeleton.ts
+++ b/lib/tools/generate-skeleton.ts
@@ -1,7 +1,7 @@
 import { Config } from "../types/config";
 import util from "util";
 import { outputInfoBanner } from "./helpers";
-
+import {ManagedRuleGroupVendor, AwsManagedRules, WebAclScope, WebAclTypeEnum} from "../../lib/types/enums";
 /**
  * The script will output a example WAF Skeleton Config to the terminal
  */
@@ -25,29 +25,26 @@ const skeletonConfig : Config = {
     PreProcess: {
       ManagedRuleGroups: [
         {
-          vendor: "AWS",
-          name: "AWSManagedRulesAmazonIpReputationList",
-          capacity: 25,
-          version: ""
+          vendor: ManagedRuleGroupVendor.AWS,
+          name: AwsManagedRules.AMAZON_IP_REPUTATION_LIST,
         },
         {
-          vendor: "AWS",
-          name: "AWSManagedRulesCommonRuleSet",
-          capacity: 700,
-          version: "",
+          vendor: ManagedRuleGroupVendor.AWS,
+          name: AwsManagedRules.COMMON_RULE_SET,
         }
       ]
     },
     PostProcess: {
 
     },
-    Scope: "REGIONAL",
-    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
+    Scope: WebAclScope.REGIONAL,
+    Type: WebAclTypeEnum.ELASTICLOADBALANCINGV2_LOADBALANCER
   }
 };
 
 outputInfoBanner();
 console.log("ℹ️  Use the following snippet to create a skeleton config file for your Firewall. ℹ️\n");
+console.log("import {ManagedRuleGroupVendor, AwsManagedRules, WebAclScope, WebAclTypeEnum} from \"../../lib/types/enums\";");
 console.log("import { Config } from \"../../lib/types/config\";\nexport const config: Config = {");
 console.log(util.inspect(skeletonConfig, false, null, true));
 console.log("};");

--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -2,6 +2,7 @@
 import { Rule, ManagedRuleGroup } from "./fms";
 import { aws_fms as fms } from "aws-cdk-lib";
 import { CfnTag } from "aws-cdk-lib";
+import * as fwmEnums from "./enums";
 
 export interface Config {
   readonly General: {
@@ -23,14 +24,15 @@ export interface Config {
     readonly Description?: string,
     readonly IncludeMap:  fms.CfnPolicy.IEMapProperty,
     readonly ExcludeMap?: fms.CfnPolicy.IEMapProperty,
-    readonly Scope: "CLOUDFRONT" | "REGIONAL",
-    readonly Type: WebAclType | "ResourceTypeList",
-    readonly TypeList?: WebAclType[],
+    readonly Scope: fwmEnums.WebAclScope | "CLOUDFRONT" | "REGIONAL",
+    readonly Type: fwmEnums.WebAclTypeEnum | "ResourceTypeList" | WebAclType,
+    readonly TypeList?: fwmEnums.WebAclTypeEnum[] | WebAclType[],
     readonly ResourceTags?: Array<fms.CfnPolicy.ResourceTagProperty>,
     readonly ExcludeResourceTags?: boolean,
     readonly RemediationEnabled?: boolean,
     readonly ResourcesCleanUp?: boolean,
     readonly IPSets?: IPSet[],
+    readonly RegexPatternSets?: RegexPatternSet[];
     readonly PreProcess: RuleGroupSet,
     readonly PostProcess: RuleGroupSet,
   },
@@ -98,7 +100,7 @@ export type CustomResponseBodies = { [key:string]: {
     * @TJS-pattern [\s\S]*
   */
   Content: string,
-  ContentType: "APPLICATION_JSON" | "TEXT_HTML" | "TEXT_PLAIN",
+  ContentType: fwmEnums.CustomResponseBodiesContentType,
 }};
 
 export interface RuleGroupSet {
@@ -131,4 +133,16 @@ export interface IPSet {
   tags?: CfnTag[]
 }
 
+export interface RegexPatternSet {
+  /**
+    * @TJS-pattern ^[a-zA-Z0-9]+$
+  */
+  name: string, // This name will be used as a CloudFormation logical ID, so it can't have a already used name and must be alphanumeric
+  /*
+    * @TJS-pattern ^[\w+=:#@\/\-,\.][\w+=:#@\/\-,\.\s]+[\w+=:#@\/\-,\.]$
+  */
+  description?: string,
+  regularExpressionList: string[],
+  tags?: CfnTag[]
+}
 export const NONEVERSIONEDMANAGEDRULEGRPOUP = ["AWSManagedRulesBotControlRuleSet","AWSManagedRulesATPRuleSet","AWSManagedRulesACFPRuleSet","AWSManagedRulesAmazonIpReputationList","AWSManagedRulesAnonymousIpList"];

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -1,0 +1,87 @@
+/**
+ * These typescript enums used in aws firewall manager
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/enums.html
+ * @see https://aws.amazon.com/en/firewall-manager/
+ */
+
+/**
+ * Specifies whether this is for an Amazon CloudFront distribution or for a regional application.
+ * A regional application can be
+ * - an Application Load Balancer (ALB),
+ * - an Amazon API Gateway REST API,
+ * - an AWS AppSync GraphQL API,
+ * - an Amazon Cognito user pool,
+ * - an AWS App Runner service,
+ * - or an AWS Verified Access instance.
+ *
+ * Valid Values are CLOUDFRONT and REGIONAL.
+ *
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html
+ */
+export enum WebAclScope {
+  CLOUDFRONT = "CLOUDFRONT",
+  REGIONAL = "REGIONAL"
+}
+
+/**
+ * List of REGIONAL AWS Managed Rule Groups
+ * @see  https://docs.aws.amazon.com/waf/latest/APIReference/API_ListAvailableManagedRuleGroups.html
+ * @see https://docs.aws.amazon.com/cli/latest/reference/wafv2/list-available-managed-rule-groups.html
+ * SDK command:
+ * Regional:
+ *  aws wafv2 list-available-managed-rule-groups --scope REGIONAL |jq -r ".[] | .[] | .Name"
+ * Cloudfront
+ *  aws wafv2 list-available-managed-rule-groups --scope REGIONAL --region=us-east-1|jq -r ".[] | .[] | .Name"
+ */
+export enum AwsManagedRules {
+  COMMON_RULE_SET = "AWSManagedRulesCommonRuleSet",
+  ADMIN_PROTECTION_RULE_SET = "AWSManagedRulesAdminProtectionRuleSet",
+  KNOWN_BAD_INPUTS_RULE_SET = "AWSManagedRulesKnownBadInputsRuleSet",
+  SQLI_RULE_SET = "AWSManagedRulesSQLiRuleSet",
+  LINUX_RULE_SET = "AWSManagedRulesLinuxRuleSet",
+  UNIX_RULE_SET = "AWSManagedRulesUnixRuleSet",
+  WINDOWS_RULE_SET = "AWSManagedRulesWindowsRuleSet",
+  PHP_RULE_SET = "AWSManagedRulesPHPRuleSet",
+  WORDPRESS_RULE_SET = "AWSManagedRulesWordPressRuleSet",
+  AMAZON_IP_REPUTATION_LIST = "AWSManagedRulesAmazonIpReputationList",
+  ANONYMOUS_IP_LIST = "AWSManagedRulesAnonymousIpList",
+  BOT_CONTROL_RULE_SET = "AWSManagedRulesBotControlRuleSet",
+  ATP_RULE_SET = "AWSManagedRulesATPRuleSet",
+  ACFP_RULE_SET = "AWSManagedRulesACFPRuleSet"
+}
+
+/**
+ * AWS Managed roule Group Vendor
+ */
+export enum ManagedRuleGroupVendor {
+  AWS = "AWS"
+}
+
+/**
+ * AWS WAF Content Type
+ *
+ * The type of content in the payload that you are defining in the Content string.
+ *
+ * @see https://docs.aws.amazon.com/waf/latest/APIReference/API_CustomResponseBody.html
+ */
+export enum CustomResponseBodiesContentType {
+  APPLICATION_JSON = "APPLICATION_JSON",
+  TEXT_HTML = "TEXT_HTML",
+  TEXT_PLAIN = "TEXT_PLAIN",
+}
+
+/**
+ * enum for supporte webacl types
+ * following types are waiting for support if you need a GraphQLApi Firewall just use an ApiGateway:Stage Firewall
+ *  - "AWS::Cognito::UserPool"
+ *  - "AWS::AppSync::GraphQLApi"
+ */
+export enum WebAclTypeEnum {
+  ELASTICLOADBALANCINGV2_LOADBALANCER = "AWS::ElasticLoadBalancingV2::LoadBalancer",
+  CLOUDFRONT_DISTRIBUTION = "AWS::CloudFront::Distribution",
+  APIGATEWAYV2_API = "AWS::ApiGatewayV2::Api",
+  APIGATEWAY_STAGE = "AWS::ApiGateway::Stage",
+  COGNITO_USERPOOL = "AWS::Cognito::UserPool",
+  APPSYNC_GRAPHQLAPI  = "AWS::AppSync::GraphQLApi"
+}

--- a/lib/types/fms.ts
+++ b/lib/types/fms.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import { aws_wafv2 as waf } from "aws-cdk-lib";
+import * as fwmEnums from "./enums";
 
 interface CustomRequestHandling {
   customRequestHandling?: {
@@ -59,10 +60,10 @@ type NameObject = {
   name: string
 }
 export interface ManagedRuleGroup {
-  vendor: string,
-  name: string,
-  version: string,
-  capacity: number,
+  vendor: fwmEnums.ManagedRuleGroupVendor | string | "AWS",
+  name: fwmEnums.AwsManagedRules | string,
+  version?: string,
+  capacity?: number,
   excludeRules?: NameObject[],
   overrideAction?: {
     type: "COUNT" | "NONE"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,13 +22,15 @@
         "aws-lambda": "^1.0.7",
         "cfonts": "^3.2.0",
         "constructs": "10.2.25",
-        "lodash": "4.17.21"
+        "lodash": "4.17.21",
+        "uuid": "^9.0.1"
       },
       "bin": {
         "firewallfactory": "bin/aws-firewall-factory.js"
       },
       "devDependencies": {
         "@types/node": "18.16.3",
+        "@types/uuid": "^9.0.4",
         "@typescript-eslint/eslint-plugin": "6.4.1",
         "@typescript-eslint/parser": "6.0.0",
         "aws-cdk": "^2.93.0",
@@ -214,6 +216,14 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://repo.entw.bconnect.barmer.de/artifactory/api/npm/npm/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch": {
@@ -2338,6 +2348,14 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://repo.entw.bconnect.barmer.de/artifactory/api/npm/npm/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@smithy/middleware-serde": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.5.tgz",
@@ -2822,6 +2840,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.4",
+      "resolved": "https://repo.entw.bconnect.barmer.de/artifactory/api/npm/npm/@types/uuid/-/uuid-9.0.4.tgz",
+      "integrity": "sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -7818,9 +7842,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-firewall-factory",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "bin": {
     "firewallfactory": "bin/aws-firewall-factory.js"
   },
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@types/node": "18.16.3",
+    "@types/uuid": "^9.0.4",
     "@typescript-eslint/eslint-plugin": "6.4.1",
     "@typescript-eslint/parser": "6.0.0",
     "aws-cdk": "^2.93.0",
@@ -37,6 +38,7 @@
     "aws-lambda": "^1.0.7",
     "cfonts": "^3.2.0",
     "constructs": "10.2.25",
-    "lodash": "4.17.21"
+    "lodash": "4.17.21",
+    "uuid": "^9.0.1"
   }
 }

--- a/values/examples/owasptop10.ts
+++ b/values/examples/owasptop10.ts
@@ -1,4 +1,5 @@
 import { Config } from "../../lib/types/config";
+import {ManagedRuleGroupVendor, AwsManagedRules, WebAclScope, WebAclTypeEnum} from "../../lib/types/enums";
 export const config: Config = {
   General: {
     DeployHash: "",
@@ -18,47 +19,35 @@ export const config: Config = {
     PreProcess: {
       ManagedRuleGroups: [
         {
-          vendor: "AWS",
-          name: "AWSManagedRulesAmazonIpReputationList",
-          version: "",
-          capacity: 25
+          vendor: ManagedRuleGroupVendor.AWS,
+          name: AwsManagedRules.AMAZON_IP_REPUTATION_LIST,
         },
         {
-          vendor: "AWS",
-          name: "AWSManagedRulesAnonymousIpList",
-          version: "",
-          capacity: 50
+          vendor: ManagedRuleGroupVendor.AWS,
+          name: AwsManagedRules.ANONYMOUS_IP_LIST,
         },
         {
-          vendor: "AWS",
-          name: "AWSManagedRulesBotControlRuleSet",
-          version: "",
-          capacity: 50
+          vendor: ManagedRuleGroupVendor.AWS,
+          name: AwsManagedRules.BOT_CONTROL_RULE_SET,
         },
         {
-          vendor: "AWS",
-          name: "AWSManagedRulesCommonRuleSet",
-          version: "",
-          capacity: 700
+          vendor: ManagedRuleGroupVendor.AWS,
+          name: AwsManagedRules.COMMON_RULE_SET,
         },
         {
-          vendor: "AWS",
-          name: "AWSManagedRulesKnownBadInputsRuleSet",
-          version: "",
-          capacity: 200
+          vendor: ManagedRuleGroupVendor.AWS,
+          name: AwsManagedRules.KNOWN_BAD_INPUTS_RULE_SET,
         },
         {
-          vendor: "AWS",
-          name: "AWSManagedRulesSQLiRuleSet",
-          version: "",
-          capacity: 200
+          vendor: ManagedRuleGroupVendor.AWS,
+          name: AwsManagedRules.SQLI_RULE_SET,
         }
       ]
     },
     PostProcess: {
     },
-    Scope: "REGIONAL",
-    Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
+    Scope: WebAclScope.REGIONAL,
+    Type: WebAclTypeEnum.ELASTICLOADBALANCINGV2_LOADBALANCER
   }
 
 };


### PR DESCRIPTION
# Change Log

## Released
## 4.1.0

### Added
- This update presents a new feature that centralizes the management of RegexPatternSet. With this improvement, manual updates of regexpatternset across multiple AWS accounts are no longer necessary. Users can now define the feature in code and replicate it for use by WAF rules wherever applicable.
- Additionally, cdk destroy has been included in the taskfile.
- Furthermore, we have modified several enums to enhance their ease of with previous versions: use while maintaining downward compatibility, such as
  - WebAclScope
  - AwsManagedRules
  - ManagedRuleGroupVendor
  - CustomResponseBodiesContentType
  - WebAclTypeEnum
- uuidFirewallFactoryResourceIdentitfier: Introducing a firewall identifier UUID that will be utilized for resource names in AWS.

### Fixed
- Capacity and version information for Managed Rule Groups are now optional. We calculate the capacity on the fly, so specifying capacity is unnecessary. If no version is provided, we will retrieve the latest version for the Managed Rule Group using the API.
- DeliveryStreamName not checked - Erroneous if exceeding 64 character limit [source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisfirehose-deliverystream.html#cfn-kinesisfirehose-deliverystream-deliverystreamname).
- Fixed nonfunctional documentation links.

### Removed
- Export names from CloudFormation stack outputs, as we rely on the stack name and output names from the particular CloudFormation stack to obtain the necessary information. ## 4.0.0
### Added
- A custom resource to retrieve the latest version of the ManagedRuleGroup and check if the specified version is valid.