### PR TITLE
4.1.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,13 +7,13 @@ assignees: ''
 
 ---
 
-**Describe the bug
+**Describe the bug**
 A clear and concise description of what the bug is.
 
-**How to reproduce it
+**How to reproduce it**
 Steps to reproduce the behaviour.
 
-**Expected behaviour
+**Expected behaviour**
 A clear and concise description of what you expect to happen.
 
 **Please fill in the following information about the solution:**.
@@ -25,5 +25,5 @@ A clear and concise description of what you expect to happen.
 **Screenshots**.
 If applicable, add screenshots to help explain your problem (please **do NOT include sensitive information**).
 
-**Additional context
+**Additional context**
 Add any other context to the issue here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Change Log
 
 ## Released
+## 4.1.1
+### Added
+- Added Console output if ManagedRuleGroup OverrideAction is set to Count - This option is not commonly used. If any rule in the rule group results in a match, this override sets the resulting action from the rule group to Count.
+- Enums for all AWS ManagedRuleGroup Rules and Labels, this will help you to not create exclude Rules of Label Match Statements for none existing Rules or Labels. AWS CloudFormation even not trow any error right now if you try use not existing Labels or Rules.
+- Optional Lambda function to prerequisite Stack that sends notifications about changes in AWS managed rule groups, such as upcoming new versions and urgent security updates, to messaging platforms like Slack or Teams.
+### Fixed
+- RegexPatternSets and IPSets in NotStatements AWS Firewall Factory are ignored while WCU calculation
+- gotestwaf task was not customized for Typescript configuration files.
+- ManagedRuleGroupVersion lambda was always using the latest ManagedRulegroup version if no version was specified. Now the lambda function is using the [current Default version](https://docs.aws.amazon.com/waf/latest/developerguide/waf-managed-rule-groups-versioning.html).
+- Added Optional Parameter for ManagedRuleGroupVersion lambda, you can now set enforceUpdate to load the latest or the current Default version during WAF update.
+- Bump @aws-cdk-lib from 2.93.0 to 2.100.0
+- Bump @aws-cdk from 2.93.0 to 2.100.0
+- Bump @aws-sdk/client-cloudformation from 3.398.0 to 3.427.0
+- Bump @aws-sdk/client-cloudwatch from 3.398.0 to 3.427.0
+- Bump @aws-sdk/client-fms from 3.398.0 to 3.427.0
+- Bump @aws-sdk/client-pricing from 3.398.0 to 3.427.0
+- Bump @aws-sdk/client-service-quotas from 3.398.0 to 3.427.0
+- Bump @aws-sdk/client-shield from 3.398.0 to 3.427.0
+- Bump @aws-sdk/client-wafv2 from 3.398.0 to 3.427.0
+- Bump @typescript-eslint/eslint-plugin from 6.4.1 to 6.7.4
+
 ## 4.1.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ If you want to learn more about the AWS Firewall Factory feel free to look at th
 #### 🔗 Useful Links
 
 - [🐦🤖 Twitter Bot to get Notified for Managed Rules Updates](https://twitter.com/AWSMgMtRulesBot)
-- [🔔 Slack automation to get Notified for Managed Rules Updates](https://github.com/globaldatanet/WAF-Managed-Rules-Update-Slack-Notification-Service)
 - [🏫 AWS WAF Workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/c2f03000-cf61-42a6-8e62-9eaf04907417/en-US/02-custom-rules)
 ## 🗺️ Architecture
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -73,7 +73,7 @@ tasks:
   creatediagram:
     desc: Create Diagram
     cmds:
-      - if [[ {{.CREATE_DIAGRAM}} = true ]] ; then echo 🤳🏻 $(cfn-dia draw.io -t cdk.out/"$(cat values/{{.config}}.json | jq -r '.General.Prefix')-WAF-$(cat values/{{.config}}.json | jq -r '.WebAcl.Name')-$(cat values/{{.config}}.json | jq -r '.General.Stage')-$(cat values/{{.config}}.json | jq -r '.General.DeployHash')".template.json --output-file $(sed "s/values/diagrams/g;s/.json/.drawio/g" <<< values/{{.config}}.json) --ci-mode --skip-synth); else echo ⏭   Skipping Diagram generation 🤳🏻 ; fi
+      - if [[ {{.CREATE_DIAGRAM}} = true ]] ; then echo 🤳🏻 $(cfn-dia draw.io -t cdk.out/"$(ts-node ./gotestwaf/gotestwaf.ts| jq -r '.General.Prefix')-WAF-$(ts-node ./gotestwaf/gotestwaf.ts| jq -r '.WebAcl.Name')-$(ts-node ./gotestwaf/gotestwaf.ts| jq -r '.General.Stage')-$(ts-node ./gotestwaf/gotestwaf.ts| jq -r '.General.DeployHash')".template.json --output-file $(sed "s/values/diagrams/g;s/.json/.drawio/g" <<< values/{{.config}}.json) --ci-mode --skip-synth); else echo ⏭   Skipping Diagram generation 🤳🏻 ; fi
     silent: true
     env:
       PROCESS_PARAMETERS: values/{{.config}}.json
@@ -81,13 +81,16 @@ tasks:
     desc: Test of your waf using GoTestWAF
     cmds:
       - echo 🧪  Testing of your new 🔥 WAF using GoTestWAF
+      - mkdir -p ./waf-evaluation-report/$(date '+%Y-%m-%d')
       - |
-        items=$(cat values/{{.config}}.json | jq -r '.[] | .SecuredDomain[]?')
+        items=$(ts-node ./gotestwaf/gotestwaf.ts | jq -r '.[] | .SecuredDomain[]?')
         for item in ${items[@]}; do
-            echo "Using fqdn in 🖥 url : $item"
-            ./gotestwaf/gotestwaf --url https://$item --workers 50 --blockConnReset  --wafName="$(cat values/{{.config}}.json | jq -r '.General.Prefix')-$(cat values/{{.config}}.json | jq -r '.WebAcl.Name')-$(cat values/{{.config}}.json | jq -r '.General.Stage')-$(cat values/{{.config}}.json | jq -r '.General.DeployHash')" --configPath=./gotestwaf/config.yaml --testCasesPath=./gotestwaf/testcases --skipWAFBlockCheck --reportPath "./waf-evaluation-report/$(date '+%Y-%m-%d')" --reportName "$(cat values/{{.config}}.json | jq -r '.General.Prefix')-$(cat values/{{.config}}.json | jq -r '.WebAcl.Name')-$(cat values/{{.config}}.json | jq -r '.General.Stage')-$(cat values/{{.config}}.json | jq -r '.General.DeployHash')"
+            echo "Using fqdn in 🖥  url : $item"
+            ./gotestwaf/gotestwaf --url https://$item --workers 50 --blockConnReset  --wafName="$(ts-node ./gotestwaf/gotestwaf.ts| jq -r '.General.Prefix')-$(ts-node ./gotestwaf/gotestwaf.ts| jq -r '.WebAcl.Name')-$(ts-node ./gotestwaf/gotestwaf.ts| jq -r '.General.Stage')-$(ts-node ./gotestwaf/gotestwaf.ts| jq -r '.General.DeployHash')" --configPath=./gotestwaf/config.yaml --testCasesPath=./gotestwaf/testcases --skipWAFBlockCheck --reportPath "./waf-evaluation-report/$(date '+%Y-%m-%d')" --reportName "$(ts-node ./gotestwaf/gotestwaf.ts| jq -r '.General.Prefix')-$(ts-node ./gotestwaf/gotestwaf.ts| jq -r '.WebAcl.Name')-$(ts-node ./gotestwaf/gotestwaf.ts| jq -r '.General.Stage')-$(ts-node ./gotestwaf/gotestwaf.ts| jq -r '.General.DeployHash')"
         done
     silent: true
+    env:
+      PROCESS_PARAMETERS: "{{.config}}"
     preconditions:
       - sh: "[ '{{.WAF_TEST}}' != 'true' ]"
         msg: ⏭  Skipping WAF Testing 🧪

--- a/lib/lambda/ManagedRuleGroupInfo/index.py
+++ b/lib/lambda/ManagedRuleGroupInfo/index.py
@@ -1,0 +1,136 @@
+import json
+import logging
+import os
+import urllib.request
+import boto3
+
+wafv2 = boto3.client('wafv2')
+
+HOOK_URL = os.environ['WebhookUrl']
+MESSENGER = os.environ['Messenger']
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def get_latest_default_rule_set_version(rule_set_name):
+    try:
+        response = wafv2.list_available_managed_rule_group_versions(Name=rule_set_name, Scope='REGIONAL', VendorName='AWS')
+        DefaultVersion = response.get('CurrentDefaultVersion')
+        return DefaultVersion
+    except Exception as e:
+        print('Error getting the default version for the rule set:', str(e))
+        return None
+
+
+def format_slack_message(data, latest_default_rule_set_version):
+    payload = {
+        'username': f"WAF {data['Type']}",
+        'icon_emoji': ':managedrule:',
+        'text': f"{data['Subject']}",
+        'attachments': [
+            {
+                'fallback': "Detailed information on {data['Type']}.",
+                'color': 'green',
+                'title': data['Subject'],
+                'text': data['Message'],
+                'fields': [
+                    {
+                        'title': 'Managed Rule Group',
+                        'value': data['MessageAttributes']['managed_rule_group']['Value'],
+                        'short': True
+                    },
+                    {
+                        'title': 'Default Version',
+                        'value': latest_default_rule_set_version,
+                        'short': True
+                    },
+                    {
+                        'title': 'Info',
+                        'value': "AWS WAF sets the default version to the static version recommended by the provider. Default version is automatically updated when the provider recommends a new version.",
+                        'short': False
+                    }
+                ]
+            }
+        ]
+    }
+    return payload
+
+
+def format_teams_message(data, latest_default_rule_set_version):
+    message = {
+        "type":"message",
+        "attachments":[
+            {
+            "contentType":"application/vnd.microsoft.card.adaptive",
+            "contentUrl": "",
+            "content":{
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                "type": "AdaptiveCard",
+                "msteams": {
+                    "width": "Full"
+                },
+                "version": "1.4",
+                "body": [
+                {
+                    "type": "TextBlock",
+                    "text": f"{data['Subject']}",
+                    "size": "Large",
+                    "weight": "Bolder",
+                    "wrap": True
+                },
+                {
+                    "type": "TextBlock",
+                    "text": f"{data['Message']}",
+                    "separator": True,
+                    "wrap": True
+                },
+                {
+                    "type": "FactSet",
+                    "facts": [
+                        {
+                            "title": "Managed Rule Group",
+                            "value": data['MessageAttributes']['managed_rule_group']['Value']
+                        },
+                        {
+                            "title": "Default Version",
+                            "value": latest_default_rule_set_version
+                        }
+                    ],
+                    "separator": True
+                },
+                {
+                    "type": "TextBlock",
+                    "text": f"AWS WAF sets the default version to the static version recommended by the provider. Default version is automatically updated when the provider recommends a new version.",
+                    "separator": True,
+                    "wrap": True
+                }
+                ]
+            }
+            }
+        ]
+    }
+    return message
+
+
+def notify(url, payload):
+    data = json.dumps(payload).encode('utf-8')
+    method = 'POST'
+    headers = {'Content-Type': 'application/json'}
+
+    request = urllib.request.Request(url, data = data, method = method, headers = headers)
+    with urllib.request.urlopen(request) as response:
+        return response.read().decode('utf-8')
+
+
+def lambda_handler(event, context):
+    logger.info("Message: " + str(event))
+    for(record) in event['Records']:
+        default_version = get_latest_default_rule_set_version(record['Sns']['MessageAttributes']['managed_rule_group']['Value'])
+        if(MESSENGER == "Slack"):
+            payload = format_slack_message(record['Sns'], default_version)
+        elif(MESSENGER == "Teams"):
+            payload = format_teams_message(record['Sns'], default_version)
+    response = notify(HOOK_URL, payload)
+    print(response)
+

--- a/lib/lambda/ManagedRuleGroupVersion/services/waf.ts
+++ b/lib/lambda/ManagedRuleGroupVersion/services/waf.ts
@@ -45,9 +45,9 @@ async function getManagedRuleGroupVersions(VendorName: string,Name: string,Scope
 }
 
 
-export async function getManagedRuleGroupVersion(VendorName: string,Name: string,Scope: string, ParamVersion?: string, Latest?: boolean): Promise<ManagedRuleGroupVersionResponse> {
+export async function getManagedRuleGroupVersion(VendorName: string,Name: string,Scope: string, ParamVersion?: string, Latest?: boolean, enforceUpdate?: boolean): Promise<ManagedRuleGroupVersionResponse> {
   const managerulegroupVersions = await getManagedRuleGroupVersions(VendorName,Name,Scope);
-  if(ParamVersion && managerulegroupVersions.Versions){
+  if(ParamVersion && managerulegroupVersions.Versions && !enforceUpdate){
     console.log("🧪 Version to check: " + ParamVersion);
     if(managerulegroupVersions.Versions.filter((MgnVersion) => MgnVersion.Name === ParamVersion)){
       console.log(`✅ Version found - ${ParamVersion} is valid`);
@@ -57,12 +57,15 @@ export async function getManagedRuleGroupVersion(VendorName: string,Name: string
       return {Version: ParamVersion, State: "FAILED", Description: "Specified Version not found"};
     }
   }
-  if(Latest && managerulegroupVersions.CurrentDefaultVersion){
-    console.log("✅ Latest version is: " + managerulegroupVersions.CurrentDefaultVersion);
-    return {Version: managerulegroupVersions.CurrentDefaultVersion, State: "SUCCESS", Description: "Version found"};
+  if(Latest){
+    const latestVersion = managerulegroupVersions.Versions.reduce((ver, curr) => {
+      return curr.LastUpdateTimestamp! > ver.LastUpdateTimestamp! ? curr : ver;
+    });
+    console.log("✅ Latest version is: " + latestVersion.Name);
+    return {Version: latestVersion.Name!, State: "SUCCESS", Description: "Version found"};
   }
   if(managerulegroupVersions.CurrentDefaultVersion){
-    console.log("✅ Latest version is: " + managerulegroupVersions.CurrentDefaultVersion);
+    console.log("✅ Current default version is: " + managerulegroupVersions.CurrentDefaultVersion);
     return {Version: managerulegroupVersions.CurrentDefaultVersion, State: "SUCCESS", Description: "Version found"};
   }
   if(managerulegroupVersions.Error){

--- a/lib/prerequisites-stack.ts
+++ b/lib/prerequisites-stack.ts
@@ -4,6 +4,9 @@ import { Prerequisites } from "./types/config";
 import { aws_s3 as s3 } from "aws-cdk-lib";
 import { aws_kms as kms } from "aws-cdk-lib";
 import { aws_iam as iam } from "aws-cdk-lib";
+import { aws_lambda as lambda } from "aws-cdk-lib";
+import { aws_logs as logs } from "aws-cdk-lib";
+
 export interface StackProps extends cdk.StackProps {
     readonly prerequisites: Prerequisites;
   }
@@ -15,84 +18,121 @@ export class PrerequisitesStack extends cdk.Stack {
     const accountId = cdk.Aws.ACCOUNT_ID;
     const region = cdk.Aws.REGION;
 
-
-    if(props.prerequisites.Logging.FireHoseKey) {
-      console.log("🔑  Creating KMS Key for Kinesis FireHose.");
-      const fireHoseKey = new kms.Key(this, "AWS-Firewall-Factory-FireHoseEncryptionKey", {
-        enableKeyRotation: true,
-        alias: props.prerequisites.General.Prefix.toLocaleLowerCase() + "-AWS-Firewall-Factory-FireHoseKey"
+    if(props.prerequisites.Information){
+      console.log("📢  Creating Lambda Function to send AWS managed rule group change status notifications to messengers (Slack/Teams)");
+      let Messenger:string = "";
+      let WebhookUrl:string = "";
+      if(props.prerequisites.Information.SlackWebhook) {
+        Messenger="Slack";
+        WebhookUrl=props.prerequisites.Information.SlackWebhook;
+      }
+      if(props.prerequisites.Information.TeamsWebhook) {
+        Messenger="Teams";
+        WebhookUrl=props.prerequisites.Information.TeamsWebhook;
+      }
+      const ManagedRuleGroupInfo = new lambda.Function(this, "AWS-Firewall-Factory-ManagedRuleGroupInfo", {
+        runtime: lambda.Runtime.PYTHON_3_11,
+        code: lambda.Code.fromAsset("./lib/lambda/ManagedRuleGroupInfo"),
+        handler: "index.lambda_handler",
+        timeout: cdk.Duration.seconds(30),
+        environment: {
+          "Messenger": Messenger,
+          "WebhookUrl": WebhookUrl,
+        },
+        logRetention: logs.RetentionDays.ONE_WEEK,
+        description: "Lambda Function to send AWS managed rule group change status notifications (like upcoming new versions and urgent security updates) to messengers (Slack/Teams)",
       });
-      if(props.prerequisites.Logging.CrossAccountIdforPermissions) {
-        console.log("➕ Adding CrossAccount Permission for KMS Key: " + props.prerequisites.General.Prefix.toLocaleLowerCase() + "-AWS-Firewall-Factory-FireHoseKey \n\n");
-        fireHoseKey.grantEncryptDecrypt(new iam.AccountPrincipal(props.prerequisites.Logging.CrossAccountIdforPermissions));
-      }
+      ManagedRuleGroupInfo.addToRolePolicy(new iam.PolicyStatement({
+        actions: ["wafv2:ListAvailableManagedRuleGroupVersions"],
+        resources: ["*"],
+      }));
+      ManagedRuleGroupInfo.addPermission("InvokeByAwsSnsTopic", {
+        action: "lambda:InvokeFunction",
+        principal: new iam.ServicePrincipal("sns.amazonaws.com"),
+        sourceArn: "arn:aws:sns:us-east-1:248400274283:aws-managed-waf-rule-notifications",
+      });
     }
-    if(props.prerequisites.Logging.BucketProperties){
-      console.log("\n🪣  Creating Bucket with Name: AWS-Firewall-Factory-Logging");
-      let encryptionKey = undefined;
-      if(props.prerequisites.Logging.BucketProperties?.KmsEncryptionKey){
-        console.log("   🔑 Creating KMS Key for: AWS-Firewall-Factory-Logging Bucket.");
-        encryptionKey = new kms.Key(this, "AWS-Firewall-Factory-LoggingEncryptionKey", {
+
+    if(props.prerequisites.Logging) {
+      if(props.prerequisites.Logging.FireHoseKey) {
+        console.log("🔑  Creating KMS Key for Kinesis FireHose.");
+        const fireHoseKey = new kms.Key(this, "AWS-Firewall-Factory-FireHoseEncryptionKey", {
           enableKeyRotation: true,
-          alias: props.prerequisites.General.Prefix.toLocaleLowerCase() + "-AWS-Firewall-Factory-" + "LogsKey"
+          alias: props.prerequisites.General.Prefix.toLocaleLowerCase() + "-AWS-Firewall-Factory-FireHoseKey"
         });
+        if(props.prerequisites.Logging.CrossAccountIdforPermissions) {
+          console.log("➕ Adding CrossAccount Permission for KMS Key: " + props.prerequisites.General.Prefix.toLocaleLowerCase() + "-AWS-Firewall-Factory-FireHoseKey \n\n");
+          fireHoseKey.grantEncryptDecrypt(new iam.AccountPrincipal(props.prerequisites.Logging.CrossAccountIdforPermissions));
+        }
       }
-      /**
+      if(props.prerequisites.Logging.BucketProperties){
+        console.log("\n🪣  Creating Bucket with Name: AWS-Firewall-Factory-Logging");
+        let encryptionKey = undefined;
+        if(props.prerequisites.Logging.BucketProperties?.KmsEncryptionKey){
+          console.log("   🔑 Creating KMS Key for: AWS-Firewall-Factory-Logging Bucket.");
+          encryptionKey = new kms.Key(this, "AWS-Firewall-Factory-LoggingEncryptionKey", {
+            enableKeyRotation: true,
+            alias: props.prerequisites.General.Prefix.toLocaleLowerCase() + "-AWS-Firewall-Factory-" + "LogsKey"
+          });
+        }
+        /**
          * Move all objects to IA after 90 days
         */
-      const lifecycleRule: s3.LifecycleRule = {
-        enabled: false,
-        id: "objects-after90days-to-ia",
-        prefix: "*",
-        transitions: [{
-          storageClass: s3.StorageClass.INFREQUENT_ACCESS,
-          transitionAfter: cdk.Duration.days(90)
-        }],
-      };
+        const lifecycleRule: s3.LifecycleRule = {
+          enabled: false,
+          id: "objects-after90days-to-ia",
+          prefix: "*",
+          transitions: [{
+            storageClass: s3.StorageClass.INFREQUENT_ACCESS,
+            transitionAfter: cdk.Duration.days(90)
+          }],
+        };
 
 
-      const accesslogsbucket = new s3.Bucket(this, "AWS-Firewall-Factory-LoggingBucket-AccessLogs", {
-        blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-        encryption: s3.BucketEncryption.S3_MANAGED,
-        enforceSSL: true,
-        lifecycleRules: [lifecycleRule],
-        versioned: true,
-        objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
-        removalPolicy: cdk.RemovalPolicy.RETAIN,
-        bucketName: props.prerequisites.Logging.BucketProperties?.BucketName ? props.prerequisites.General.Prefix.toLocaleLowerCase().toLocaleLowerCase() + "-" + props.prerequisites.Logging.BucketProperties?.BucketName + "-access-logs" : props.prerequisites.General.Prefix.toLocaleLowerCase() + "-awsfirewallfactory-logging-access-logs" + accountId + "-" + region
-      });
+        const accesslogsbucket = new s3.Bucket(this, "AWS-Firewall-Factory-LoggingBucket-AccessLogs", {
+          blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+          encryption: s3.BucketEncryption.S3_MANAGED,
+          enforceSSL: true,
+          lifecycleRules: [lifecycleRule],
+          versioned: true,
+          objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
+          removalPolicy: cdk.RemovalPolicy.RETAIN,
+          bucketName: props.prerequisites.Logging.BucketProperties?.BucketName ? props.prerequisites.General.Prefix.toLocaleLowerCase().toLocaleLowerCase() + "-" + props.prerequisites.Logging.BucketProperties?.BucketName + "-access-logs" : props.prerequisites.General.Prefix.toLocaleLowerCase() + "-awsfirewallfactory-logging-access-logs" + accountId + "-" + region
+        });
 
-      const bucket = new s3.Bucket(this, "AWS-Firewall-Factory-LoggingBucket", {
-        blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-        encryption: props.prerequisites.Logging.BucketProperties?.KmsEncryptionKey ? s3.BucketEncryption.KMS : s3.BucketEncryption.S3_MANAGED,
-        encryptionKey,
-        enforceSSL: true,
-        lifecycleRules: [lifecycleRule],
-        serverAccessLogsBucket: accesslogsbucket,
-        versioned: props.prerequisites.Logging.BucketProperties?.ObjectLock ? true : false,
-        objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
-        removalPolicy: cdk.RemovalPolicy.RETAIN,
-        bucketName: props.prerequisites.Logging.BucketProperties?.BucketName ? props.prerequisites.General.Prefix.toLocaleLowerCase() + "-" + props.prerequisites.Logging.BucketProperties?.BucketName : props.prerequisites.General.Prefix.toLocaleLowerCase() + "-awsfirewallfactory-logging-" + accountId + "-" + region
-      });
+        const bucket = new s3.Bucket(this, "AWS-Firewall-Factory-LoggingBucket", {
+          blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+          encryption: props.prerequisites.Logging.BucketProperties?.KmsEncryptionKey ? s3.BucketEncryption.KMS : s3.BucketEncryption.S3_MANAGED,
+          encryptionKey,
+          enforceSSL: true,
+          lifecycleRules: [lifecycleRule],
+          serverAccessLogsBucket: accesslogsbucket,
+          versioned: props.prerequisites.Logging.BucketProperties?.ObjectLock ? true : false,
+          objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
+          removalPolicy: cdk.RemovalPolicy.RETAIN,
+          bucketName: props.prerequisites.Logging.BucketProperties?.BucketName ? props.prerequisites.General.Prefix.toLocaleLowerCase() + "-" + props.prerequisites.Logging.BucketProperties?.BucketName : props.prerequisites.General.Prefix.toLocaleLowerCase() + "-awsfirewallfactory-logging-" + accountId + "-" + region
+        });
 
-      if(props.prerequisites.Logging.CrossAccountIdforPermissions) {
-        console.log("   ➕ Adding CrossAccount Permission for Bucket: AWS-Firewall-Factory-Logging");
-        bucket.grantReadWrite(new iam.AccountPrincipal(props.prerequisites.Logging.CrossAccountIdforPermissions));
+        if(props.prerequisites.Logging.CrossAccountIdforPermissions) {
+          console.log("   ➕ Adding CrossAccount Permission for Bucket: AWS-Firewall-Factory-Logging");
+          bucket.grantReadWrite(new iam.AccountPrincipal(props.prerequisites.Logging.CrossAccountIdforPermissions));
+        }
+        if(props.prerequisites.Logging.BucketProperties?.ObjectLock) {
+          console.log("   ➕ Adding ObjectLock to Bucket: AWS-Firewall-Factory-Logging \n");
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+          console.log("   ⚙️  Settings: \n      🗓️  Retention-Days: " + props.prerequisites.Logging.BucketProperties?.ObjectLock?.Days + "\n      🛡️  Retention-Mode: " + props.prerequisites.Logging.BucketProperties?.ObjectLock?.Mode + "\n\n");
+          // Get the CloudFormation resource because L2 Construct doenst support this Property
+          const cfnBucket = bucket.node.defaultChild as s3.CfnBucket;
+          // Add the ObjectLockConfiguration prop to the Bucket's CloudFormation output.
+          cfnBucket.addPropertyOverride("ObjectLockEnabled", true);
+          cfnBucket.addPropertyOverride("ObjectLockConfiguration.ObjectLockEnabled", "Enabled");
+          cfnBucket.addPropertyOverride("ObjectLockConfiguration.Rule.DefaultRetention.Days", props.prerequisites.Logging.BucketProperties?.ObjectLock?.Days);
+          // Can be `GOVERNANCE` or `COMPLIANCE` - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-defaultretention.html
+          cfnBucket.addPropertyOverride("ObjectLockConfiguration.Rule.DefaultRetention.Mode", props.prerequisites.Logging.BucketProperties?.ObjectLock?.Mode);
+        }
+
       }
-      if(props.prerequisites.Logging.BucketProperties?.ObjectLock) {
-        console.log("   ➕ Adding ObjectLock to Bucket: AWS-Firewall-Factory-Logging \n");
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-        console.log("   ⚙️  Settings: \n      🗓️  Retention-Days: " + props.prerequisites.Logging.BucketProperties?.ObjectLock?.Days + "\n      🛡️  Retention-Mode: " + props.prerequisites.Logging.BucketProperties?.ObjectLock?.Mode + "\n\n");
-        // Get the CloudFormation resource because L2 Construct doenst support this Property
-        const cfnBucket = bucket.node.defaultChild as s3.CfnBucket;
-        // Add the ObjectLockConfiguration prop to the Bucket's CloudFormation output.
-        cfnBucket.addPropertyOverride("ObjectLockEnabled", true);
-        cfnBucket.addPropertyOverride("ObjectLockConfiguration.ObjectLockEnabled", "Enabled");
-        cfnBucket.addPropertyOverride("ObjectLockConfiguration.Rule.DefaultRetention.Days", props.prerequisites.Logging.BucketProperties?.ObjectLock?.Days);
-        // Can be `GOVERNANCE` or `COMPLIANCE` - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-defaultretention.html
-        cfnBucket.addPropertyOverride("ObjectLockConfiguration.Rule.DefaultRetention.Mode", props.prerequisites.Logging.BucketProperties?.ObjectLock?.Mode);
-      }
-
     }
+
   }
 }

--- a/lib/tools/helpers.ts
+++ b/lib/tools/helpers.ts
@@ -289,7 +289,7 @@ async function calculateCapacities(
         managedrule.version
       );
       managedrule.capacity = capacity;
-      managedcapacitieslog.push([managedrule.name, managedrule.capacity, managedrule.version ?? "unversioned", managedrule.enforceUpdate ?? "false"]);
+      managedcapacitieslog.push([managedrule.name, managedrule.capacity, managedrule.version !== "" ? managedrule.version : "[unversioned]", managedrule.enforceUpdate ?? "false"]);
       runtimeProperties.ManagedRuleCapacity += capacity;
       runtimeProperties.PreProcess.ManagedRuleGroupCount += 1;
       managedrule.name === "AWSManagedRulesBotControlRuleSet" ? runtimeProperties.PreProcess.ManagedRuleBotControlCount +=1 : "";
@@ -312,7 +312,7 @@ async function calculateCapacities(
         config.WebAcl.Scope,
         managedrule.version
       );
-      managedcapacitieslog.push([managedrule.name, managedrule.capacity, managedrule.version ?? "unversioned", managedrule.enforceUpdate ?? "false"]);
+      managedcapacitieslog.push([managedrule.name, managedrule.capacity, managedrule.capacity, managedrule.version !== "" ? managedrule.version : "[unversioned]", managedrule.enforceUpdate ?? "false"]);
       runtimeProperties.ManagedRuleCapacity += capacity;
       runtimeProperties.PostProcess.ManagedRuleGroupCount += 1;
       managedrule.name === "AWSManagedRulesBotControlRuleSet" ? runtimeProperties.PostProcess.ManagedRuleBotControlCount +=1 : "";

--- a/lib/tools/helpers.ts
+++ b/lib/tools/helpers.ts
@@ -19,7 +19,8 @@ import { Rule as FmsRule } from "../types/fms";
 import cfonts = require("cfonts");
 import * as packageJsonObject from "../../package.json";
 import {transformCdkRuletoSdkRule} from "./transformer";
-// import * as fs from "fs";
+import { table } from "table";
+
 
 /**
  * Service Quota Code for Firewall Manager Total WAF WCU in account & region
@@ -256,6 +257,7 @@ async function calculateCapacities(
       "\n ⏭  Skip Rule Capacity Calculation for PreProcess Custom Rules."
     );
   } else {
+    console.log(" 🥇 PreProcess: ");
     runtimeProperties.PreProcess.CustomRuleCount = config.WebAcl.PreProcess.CustomRules.length;
     runtimeProperties.PreProcess.CustomCaptchaRuleCount = config.WebAcl.PreProcess.CustomRules.filter(rule => rule.action.captcha).length;
     runtimeProperties.PreProcess.Capacity = (await calculateCustomRulesCapacities(config.WebAcl.PreProcess.CustomRules, deploymentRegion, config.WebAcl.Scope)).reduce((a,b) => a+b, 0);
@@ -265,15 +267,18 @@ async function calculateCapacities(
       "\n ⏭  Skip Rule Capacity Calculation for PostProcess Custom Rules."
     );
   } else {
+    console.log("\n 🥈 PostProcess: ");
     runtimeProperties.PostProcess.CustomRuleCount = config.WebAcl.PostProcess.CustomRules.length;
     runtimeProperties.PostProcess.CustomCaptchaRuleCount = config.WebAcl.PostProcess.CustomRules.filter(rule => rule.action.captcha).length;
     runtimeProperties.PostProcess.Capacity = (await calculateCustomRulesCapacities(config.WebAcl.PostProcess.CustomRules, deploymentRegion, config.WebAcl.Scope)).reduce((a,b) => a+b, 0);
   }
   console.log("\n👀 Get ManagedRule Capacity:\n");
-  if (!config.WebAcl.PreProcess.ManagedRuleGroups) {
+  if (!config.WebAcl.PreProcess.ManagedRuleGroups || config.WebAcl.PreProcess.ManagedRuleGroups?.length === 0) {
     console.log("\n ℹ️  No ManagedRuleGroups defined in PreProcess.");
   } else {
     console.log(" 🥇 PreProcess: ");
+    const managedcapacitieslog = [];
+    managedcapacitieslog.push(["➕ RuleName", "Capacity", "🏷  Specified Version", "🔄 EnforceUpdate"]);
     for (const managedrule of config.WebAcl.PreProcess.ManagedRuleGroups) {
       managedrule.version ? managedrule.version : managedrule.version = await getcurrentManagedRuleGroupVersion(deploymentRegion, managedrule.vendor, managedrule.name, config.WebAcl.Scope);
       const capacity = await getManagedRuleCapacity(
@@ -284,24 +289,20 @@ async function calculateCapacities(
         managedrule.version
       );
       managedrule.capacity = capacity;
-      console.log(
-        "   ➕ Capacity for " +
-          managedrule.name +
-          " is [" +
-          managedrule.capacity +
-          "]"
-      );
-      managedrule.version ? console.log("      🏷  Specified " + managedrule.version) : console.log("");
+      managedcapacitieslog.push([managedrule.name, managedrule.capacity, managedrule.version ?? "unversioned", managedrule.enforceUpdate ?? "false"]);
       runtimeProperties.ManagedRuleCapacity += capacity;
       runtimeProperties.PreProcess.ManagedRuleGroupCount += 1;
       managedrule.name === "AWSManagedRulesBotControlRuleSet" ? runtimeProperties.PreProcess.ManagedRuleBotControlCount +=1 : "";
       managedrule.name === "AWSManagedRulesATPRuleSet" ? runtimeProperties.PreProcess.ManagedRuleATPCount += 1 : "";
     }
+    console.log(table(managedcapacitieslog));
   }
-  if (!config.WebAcl.PostProcess.ManagedRuleGroups) {
+  if (!config.WebAcl.PostProcess.ManagedRuleGroups  || config.WebAcl.PostProcess.ManagedRuleGroups?.length === 0) {
     console.log("\n ℹ️  No ManagedRuleGroups defined in PostProcess.");
   } else {
     console.log("\n 🥈 PostProcess: ");
+    const managedcapacitieslog = [];
+    managedcapacitieslog.push(["➕ RuleName", "Capacity", "🏷  Specified Version", "🔄 EnforceUpdate"]);
     for (const managedrule of config.WebAcl.PostProcess.ManagedRuleGroups) {
       managedrule.version ? managedrule.version : managedrule.version = await getcurrentManagedRuleGroupVersion(deploymentRegion, managedrule.vendor, managedrule.name, config.WebAcl.Scope);
       const capacity = await getManagedRuleCapacity(
@@ -311,25 +312,41 @@ async function calculateCapacities(
         config.WebAcl.Scope,
         managedrule.version
       );
-      managedrule.capacity = capacity;
-      console.log(
-        "   ➕ Capacity for " +
-          managedrule.name +
-          " is [" +
-          managedrule.capacity +
-          "]"
-      );
-      managedrule.version ? console.log("      🏷  Specified " + managedrule.version) : console.log("");
+      managedcapacitieslog.push([managedrule.name, managedrule.capacity, managedrule.version ?? "unversioned", managedrule.enforceUpdate ?? "false"]);
       runtimeProperties.ManagedRuleCapacity += capacity;
       runtimeProperties.PostProcess.ManagedRuleGroupCount += 1;
       managedrule.name === "AWSManagedRulesBotControlRuleSet" ? runtimeProperties.PostProcess.ManagedRuleBotControlCount +=1 : "";
       managedrule.name === "AWSManagedRulesATPRuleSet" ? runtimeProperties.PostProcess.ManagedRuleATPCount += 1 : "";
     }
+    console.log(table(managedcapacitieslog));
   }
 }
 
 /**
- * 
+ * Filters for AWS Firewall Factory managed IPSets and RegexPatternSets
+ * @param statement the statement to check
+ * @returns found
+ */
+function filterStatements(statement: wafv2.CfnWebACL.StatementProperty){
+  {
+    let found = true;
+    const ipSetReferenceStatement = statement.ipSetReferenceStatement as wafv2.CfnWebACL.IPSetReferenceStatementProperty | undefined;
+    const regexPatternSetReferenceStatement = statement.regexPatternSetReferenceStatement as wafv2.CfnWebACL.RegexPatternSetReferenceStatementProperty | undefined;
+    const notStatement = statement.notStatement as wafv2.CfnWebACL.NotStatementProperty | undefined;
+    if(ipSetReferenceStatement && !ipSetReferenceStatement.arn.startsWith("arn:aws:")) found = false;
+    if(regexPatternSetReferenceStatement && !regexPatternSetReferenceStatement.arn.startsWith("arn:aws:")) found = false;
+    if(notStatement) {
+      const notStatementProp = notStatement.statement as wafv2.CfnWebACL.StatementProperty;
+      const notipSetReferenceStatement = notStatementProp.ipSetReferenceStatement as wafv2.CfnWebACL.IPSetReferenceStatementProperty | undefined;
+      const notregexPatternSetReferenceStatement = notStatementProp.regexPatternSetReferenceStatement as wafv2.CfnWebACL.RegexPatternSetReferenceStatementProperty | undefined;
+      if(notipSetReferenceStatement && !notipSetReferenceStatement.arn.startsWith("arn:aws:")) found = false;
+      if(notregexPatternSetReferenceStatement && !notregexPatternSetReferenceStatement.arn.startsWith("arn:aws:")) found = false;
+    }
+    return found;
+  }
+}
+/**
+ *
  * @param customRules PreProcess Custom Rules or PostProcess Custom Rules
  * @param deploymentRegion the AWS region, e.g. eu-central-1
  * @param scope the scope of the WebACL, e.g. REGIONAL or CLOUDFRONT
@@ -337,8 +354,9 @@ async function calculateCapacities(
  */
 async function calculateCustomRulesCapacities(customRules: FmsRule[], deploymentRegion: string, scope: "REGIONAL" | "CLOUDFRONT") {
   const capacities = [];
+  const capacitieslog = [];
+  capacitieslog.push(["🔺 Priority", "➕ RuleName", "Capacity"]);
   for (const customRule of customRules) {
-    console.log("   ➕ Capacity for " + customRule.name);
     // Manually calculate and return capacity if rule has a ipset statements with a logical ID entry (e.g. ${IPsString.Arn})
     // This means the IPSet will be created by this repo, maybe it doesn't exists yet. That fails this function. That's why the code below is needed.
     const ipSetReferenceStatement = customRule.statement.ipSetReferenceStatement as wafv2.CfnWebACL.IPSetReferenceStatementProperty | undefined;
@@ -347,6 +365,8 @@ async function calculateCustomRulesCapacities(customRules: FmsRule[], deployment
     const andStatement = customRule.statement.andStatement as wafv2.CfnWebACL.AndStatementProperty | undefined;
     // in case rule has an orStatement
     const orStatement = customRule.statement.orStatement as wafv2.CfnWebACL.OrStatementProperty | undefined;
+    // in case rule has an notStatement
+    const notStatement = customRule.statement.notStatement as wafv2.CfnWebACL.NotStatementProperty | undefined;
     if(ipSetReferenceStatement && !ipSetReferenceStatement.arn.startsWith("arn:aws:")) {
       // Capacity for IPSet statements:
       // "WCUs – 1 WCU for most. If you configure the statement to use forwarded IP addresses and specify a position of ANY, increase the WCU usage by 4."
@@ -355,6 +375,20 @@ async function calculateCustomRulesCapacities(customRules: FmsRule[], deployment
     }
     else if(statementRegexPatternSetsStatement && !statementRegexPatternSetsStatement.arn.startsWith("arn:aws:")) {
       capacities.push(regexPatternSetsStatementsCapacity(statementRegexPatternSetsStatement));
+    }
+    else if(notStatement && notStatement.statement) {
+      const notStatementProp = notStatement.statement as wafv2.CfnWebACL.StatementProperty;
+      const notipSetReferenceStatement = notStatementProp.ipSetReferenceStatement as wafv2.CfnWebACL.IPSetReferenceStatementProperty | undefined;
+      const notregexPatternSetReferenceStatement = notStatementProp.regexPatternSetReferenceStatement as wafv2.CfnWebACL.RegexPatternSetReferenceStatementProperty | undefined;
+      if(notipSetReferenceStatement && !notipSetReferenceStatement.arn.startsWith("arn:aws:")) {
+        capacities.push(calculateIpsSetStatementCapacity(notipSetReferenceStatement));
+      }
+      else if(notregexPatternSetReferenceStatement && !notregexPatternSetReferenceStatement.arn.startsWith("arn:aws:")) {
+        capacities.push(regexPatternSetsStatementsCapacity(notregexPatternSetReferenceStatement));
+      }
+      else{
+        capacities.push(await calculateCustomRuleStatementsCapacity(customRule, deploymentRegion, scope));
+      }
     }
     else if(andStatement && andStatement.statements) {
       for (const statement of andStatement.statements as wafv2.CfnWebACL.StatementProperty[]) {
@@ -366,14 +400,23 @@ async function calculateCustomRulesCapacities(customRules: FmsRule[], deployment
         if(statementRegexPatternSetsStatement && !statementRegexPatternSetsStatement.arn.startsWith("arn:aws:")) {
           capacities.push(regexPatternSetsStatementsCapacity(statementRegexPatternSetsStatement));
         }
+        const notStatementStatement = statement.notStatement as wafv2.CfnWebACL.NotStatementProperty | undefined;
+        if(notStatementStatement && notStatementStatement.statement) {
+          const statement = notStatementStatement.statement as wafv2.CfnWebACL.StatementProperty;
+          const notstatementIpSetReferenceStatement = statement.ipSetReferenceStatement as wafv2.CfnWebACL.IPSetReferenceStatementProperty | undefined;
+          if(notstatementIpSetReferenceStatement && !notstatementIpSetReferenceStatement.arn.startsWith("arn:aws:")) {
+            capacities.push(calculateIpsSetStatementCapacity(notstatementIpSetReferenceStatement));
+          }
+          const notstatementRegexPatternSetsStatement = statement.regexPatternSetReferenceStatement as wafv2.CfnWebACL.RegexPatternSetReferenceStatementProperty | undefined;
+          if(notstatementRegexPatternSetsStatement && notstatementRegexPatternSetsStatement.arn.startsWith("arn:aws:")) {
+            capacities.push(regexPatternSetsStatementsCapacity(notstatementRegexPatternSetsStatement));
+          }
+        }
+
       }
       const filteredAndStatements = {
         statements: (andStatement.statements as wafv2.CfnWebACL.StatementProperty[]).filter(statement =>
-          (!statement.ipSetReferenceStatement
-        ||  (statement.ipSetReferenceStatement && statement.ipSetReferenceStatement as wafv2.CfnWebACL.IPSetReferenceStatementProperty).arn.startsWith("arn:aws:"))
-        && (!statement.regexPatternSetReferenceStatement
-        || (statement.regexPatternSetReferenceStatement && statement.regexPatternSetReferenceStatement as wafv2.CfnWebACL.RegexPatternSetReferenceStatementProperty).arn.startsWith("arn:aws:")))
-      };
+          filterStatements(statement))};
       if (filteredAndStatements && filteredAndStatements.statements && filteredAndStatements.statements.length > 0) {
         const calcRule = buildCustomRuleWithoutReferenceStatements(customRule, filteredAndStatements, false);
         const capacity = await calculateCustomRuleStatementsCapacity(calcRule, deploymentRegion, scope);
@@ -390,13 +433,22 @@ async function calculateCustomRulesCapacities(customRules: FmsRule[], deployment
         if(statementRegexPatternSetsStatement && !statementRegexPatternSetsStatement.arn.startsWith("arn:aws:")) {
           capacities.push(regexPatternSetsStatementsCapacity(statementRegexPatternSetsStatement));
         }
+        const notStatementStatement = statement.notStatement as wafv2.CfnWebACL.NotStatementProperty | undefined;
+        if(notStatementStatement && notStatementStatement.statement) {
+          const statement = notStatementStatement.statement as wafv2.CfnWebACL.StatementProperty;
+          const notstatementIpSetReferenceStatement = statement.ipSetReferenceStatement as wafv2.CfnWebACL.IPSetReferenceStatementProperty | undefined;
+          if(notstatementIpSetReferenceStatement && !notstatementIpSetReferenceStatement.arn.startsWith("arn:aws:")) {
+            capacities.push(calculateIpsSetStatementCapacity(notstatementIpSetReferenceStatement));
+          }
+          const notstatementRegexPatternSetsStatement = statement.regexPatternSetReferenceStatement as wafv2.CfnWebACL.RegexPatternSetReferenceStatementProperty | undefined;
+          if(notstatementRegexPatternSetsStatement && notstatementRegexPatternSetsStatement.arn.startsWith("arn:aws:")) {
+            capacities.push(regexPatternSetsStatementsCapacity(notstatementRegexPatternSetsStatement));
+          }
+        }
       }
       const filteredOrStatements = {
         statements: (orStatement.statements as wafv2.CfnWebACL.StatementProperty[]).filter(statement =>
-          (!statement.ipSetReferenceStatement
-        ||  (statement.ipSetReferenceStatement && statement.ipSetReferenceStatement as wafv2.CfnWebACL.IPSetReferenceStatementProperty).arn.startsWith("arn:aws:"))
-        && (!statement.regexPatternSetReferenceStatement
-        || (statement.regexPatternSetReferenceStatement && statement.regexPatternSetReferenceStatement as wafv2.CfnWebACL.RegexPatternSetReferenceStatementProperty).arn.startsWith("arn:aws:")))
+          filterStatements(statement))
       };
       if (filteredOrStatements && filteredOrStatements.statements && filteredOrStatements.statements.length > 0) {
         const calcRule = buildCustomRuleWithoutReferenceStatements(customRule, filteredOrStatements, false);
@@ -407,7 +459,10 @@ async function calculateCustomRulesCapacities(customRules: FmsRule[], deployment
     else {
       capacities.push(await calculateCustomRuleStatementsCapacity(customRule, deploymentRegion, scope));
     }
+    capacitieslog.push([customRule.priority, customRule.name,capacities[capacities.length-1]]);
   }
+  capacitieslog.sort((a, b) => parseInt(a[0] as string,10) - parseInt(b[0] as string,10));
+  console.log(table(capacitieslog));
   return capacities;
 }
 

--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -44,7 +44,11 @@ export interface Prerequisites {
   readonly General: {
     readonly Prefix: string,
   },
-  readonly Logging: {
+  readonly Information?:{
+    SlackWebhook?: string,
+    TeamsWebhook?: string,
+  }
+  readonly Logging?: {
       readonly BucketProperties?: {
         readonly BucketName?: string,
         readonly KmsEncryptionKey: boolean,

--- a/lib/types/enums.ts
+++ b/lib/types/enums.ts
@@ -52,6 +52,671 @@ export enum AwsManagedRules {
 }
 
 /**
+ * Enum for AWSManagedRulesACFPRuleSet Rules
+ */
+export enum ACFP_RULE_SET_RULES {
+  UnsupportedCognitoIDP = "UnsupportedCognitoIDP",
+  AllRequests = "AllRequests",
+  RiskScoreHigh = "RiskScoreHigh",
+  SignalCredentialCompromised = "SignalCredentialCompromised",
+  SignalClientHumanInteractivityAbsentLow = "SignalClientHumanInteractivityAbsentLow",
+  AutomatedBrowser = "AutomatedBrowser",
+  BrowserInconsistency  = "BrowserInconsistency",
+  VolumetricIpHigh = "VolumetricIpHigh",
+  VolumetricSessionHigh = "VolumetricSessionHigh",
+  AttributeUsernameTraversalHigh = "AttributeUsernameTraversalHigh",
+  VolumetricPhoneNumberHigh = "VolumetricPhoneNumberHigh",
+  VolumetricAddressHigh = "VolumetricAddressHigh",
+  VolumetricAddressLow = "VolumetricAddressLow",
+  VolumetricIPSuccessfulResponse = "VolumetricIPSuccessfulResponse",
+  VolumetricSessionSuccessfulResponse = "VolumetricSessionSuccessfulResponse",
+  VolumetricSessionTokenReuseIp = "VolumetricSessionTokenReuseIp",
+}
+
+/**
+ * Enum for AWSManagedRulesACFPRuleSet Labels
+ */
+export enum ACFP_RULE_SET_LABELS {
+  UnsupportedCognitoIDP = "awswaf:managed:aws:acfp:unsupported:cognito_idp",
+  VolumetricSessionHigh ="awswaf:managed:aws:acfp:aggregate:volumetric:session:creation:high",
+  VolumetricSessionMedium ="awswaf:managed:aws:acfp:aggregate:volumetric:session:creation:medium",
+  VolumetricSessionLow ="awswaf:managed:aws:acfp:aggregate:volumetric:session:creation:low",
+  VolumetricSessionSuccessfulResponseHigh = "awswaf:managed:aws:acfp:aggregate:volumetric:session:successful_creation_response:high",
+  VolumetricSessionSuccessfulResponseMedium = "awswaf:managed:aws:acfp:aggregate:volumetric:session:successful_creation_response:medium",
+  VolumetricSessionSuccessfulResponseLow = "awswaf:managed:aws:acfp:aggregate:volumetric:session:successful_creation_response:low",
+  VolumetricSessionFailedResponseHigh = " awswaf:managed:aws:acfp:aggregate:volumetric:session:failed_creation_response:high",
+  VolumetricSessionFailedResponseMedium = " awswaf:managed:aws:acfp:aggregate:volumetric:session:failed_creation_response:medium",
+  VolumetricSessionFailedResponseLow = " awswaf:managed:aws:acfp:aggregate:volumetric:session:failed_creation_response:low",
+  VolumetricSessionTokenReuseIp ="awswaf:managed:aws:acfp:aggregate:volumetric:session:creation:token_reuse:ip",
+  VolumetricPhoneNumberHigh ="awswaf:managed:aws:acfp:aggregate:volumetric:phone_number:high",
+  VolumetricPhoneNumberMedium ="awswaf:managed:aws:acfp:aggregate:volumetric:phone_number:medium",
+  VolumetricPhoneNumberLow ="awswaf:managed:aws:acfp:aggregate:volumetric:phone_number:low",
+  VolumetricCreationHigh = "awswaf:managed:aws:acfp:aggregate:volumetric:ip:creation:high",
+  VolumetricCreationMedium = "awswaf:managed:aws:acfp:aggregate:volumetric:ip:creation:medium",
+  VolumetricCreationLow ="awswaf:managed:aws:acfp:aggregate:volumetric:ip:creation:low",
+  VolumetricIpSuccessFulCreationHigh ="awswaf:managed:aws:acfp:aggregate:volumetric:ip:successful_creation_response:high",
+  VolumetricIpSuccessFulCreationMedium="awswaf:managed:aws:acfp:aggregate:volumetric:ip:successful_creation_response:medium",
+  VolumetricIpSuccessFulCreationLow ="awswaf:managed:aws:acfp:aggregate:volumetric:ip:successful_creation_response:low",
+  VolumetricIpFailedCreationHigh ="awswaf:managed:aws:acfp:aggregate:volumetric:ip:failed_creation_response:high",
+  VolumetricIpFailedCreationMedium="awswaf:managed:aws:acfp:aggregate:volumetric:ip:failed_creation_response:medium",
+  VolumetricIpFailedCreationLow ="awswaf:managed:aws:acfp:aggregate:volumetric:ip:failed_creation_response:low",
+  VolumetricAddressHigh ="awswaf:managed:aws:acfp:aggregate:volumetric:address:high",
+  VolumetricAddressMedium="awswaf:managed:aws:acfp:aggregate:volumetric:address:medium",
+  VolumetricAddressLow ="awswaf:managed:aws:acfp:aggregate:volumetric:address:low",
+  AttributeUsernameTraversalHigh ="awswaf:managed:aws:acfp:aggregate:attribute:username_traversal:creation:high",
+  AttributeUsernameTraversalMedium="awswaf:managed:aws:acfp:aggregate:attribute:username_traversal:creation:medium",
+  AttributeUsernameTraversalLow= "awswaf:managed:aws:acfp:aggregate:attribute:username_traversal:creation:low",
+  AutomatedBrowser ="awswaf:managed:aws:acfp:signal:automated_browser",
+  BrowserInconsistency ="awswaf:managed:aws:acfp:signal:browser_inconsistency",
+  SignalCredentialCompromised ="awswaf:managed:aws:acfp:signal:credential_compromised",
+  SignalMissingCredential ="awswaf:managed:aws:acfp:signal:missing_credential",
+  SignalCreationPage ="awswaf:managed:aws:acfp:signal:creation_page",
+  SignalRegistrationPage ="awswaf:managed:aws:acfp:signal:registration_page",
+  SignalFormDetected ="awswaf:managed:aws:acfp:signal:form_detected",
+  SignalClientHumanInteractivityAbsentHigh ="awswaf:managed:aws:acfp:signal:client:human_interactivity:high",
+  SignalClientHumanInteractivityAbsentMedium ="awswaf:managed:aws:acfp:signal:client:human_interactivity:medium",
+  SignalClientHumanInteractivityAbsentLow ="awswaf:managed:aws:acfp:signal:client:human_interactivity:low",
+  SignalClientHumanInteractivityInsufficientData ="awswaf:managed:aws:acfp:signal:client:human_interactivity:insufficient_data",
+  RiskScoreHigh ="awswaf:managed:aws:acfp:risk_score:high",
+  RiskScoreMedium ="awswaf:managed:aws:acfp:risk_score:medium",
+  RiskScoreLow ="awswaf:managed:aws:acfp:risk_score:low",
+  RiskScoreEvaluationFailed =" awswaf:managed:aws:acfp:risk_score:evaluation_failed",
+  RiskScoreContributorIpReputationHigh = "awswaf:managed:aws:acfp:risk_score:contributor:ip_reputation:high",
+  RiskScoreContributorIpReputationMedium = "awswaf:managed:aws:acfp:risk_score:contributor:ip_reputation:medium",
+  RiskScoreContributorIpReputationLow = "awswaf:managed:aws:acfp:risk_score:contributor:ip_reputation:low",
+  RiskScoreContributorIpReputationEvaluationFailed = "awswaf:managed:aws:acfp:risk_score:contributor:ip_reputation:evaluation_failed",
+  RiskScoreContributorStolenCredentialsCredentialPairHigh ="awswaf:managed:aws:acfp:risk_score:contributor:stolen_credentials_credential_pair:high",
+  RiskScoreContributorStolenCredentialsCredentialPairMedium ="awswaf:managed:aws:acfp:risk_score:contributor:stolen_credentials_credential_pair:medium",
+  RiskScoreContributorStolenCredentialsCredentialPairLow ="awswaf:managed:aws:acfp:risk_score:contributor:stolen_credentials_credential_pair:low",
+  RiskScoreContributorStolenCredentialsCredentialPairEvaluationFailed ="awswaf:managed:aws:acfp:risk_score:contributor:stolen_credentials_credential_pair:evaluation_failed",
+}
+
+/**
+ * Enum for AWSManagedRulesATPRuleSet Rules
+ */
+export enum ATP_RULE_SET_RULES {
+  UnsupportedCognitoIDP = "UnsupportedCognitoIDP",
+  VolumetricIpHigh = "VolumetricIpHigh",
+  VolumetricSession = "VolumetricSession",
+  AttributeCompromisedCredentials = "AttributeCompromisedCredentials",
+  AttributeUsernameTraversal = "AttributeUsernameTraversal",
+  AttributePasswordTraversal = "AttributePasswordTraversal",
+  AttributeLongSession = "AttributeLongSession",
+  TokenRejected = "TokenRejected",
+  SignalMissingCredential = "SignalMissingCredential",
+}
+
+/**
+ * Enum for AWSManagedRulesATPRuleSet Labels
+ */
+export enum ATP_RULE_SET_LABELS {
+  UnsupportedCognitoIDP = "awswaf:managed:aws:atp:unsupported:cognito_idp",
+  VolumetricIpHigh = "awswaf:managed:aws:atp:aggregate:volumetric:ip:high",
+  VolumetricIpMedium = "awswaf:managed:aws:atp:aggregate:volumetric:ip:medium",
+  VolumetricIpLow = "awswaf:managed:aws:atp:aggregate:volumetric:ip:low",
+  VolumemetricIpFailedLoginResponseHigh = "awswaf:managed:aws:atp:aggregate:volumetric:ip:failed_login_response:high",
+  VolumemetricIpFailedLoginResponseMedium = "awswaf:managed:aws:atp:aggregate:volumetric:ip:failed_login_response:medium",
+  VolumemetricIpFailedLoginResponseLow = "awswaf:managed:aws:atp:aggregate:volumetric:ip:failed_login_response:low",
+  VolumemetricIpSuccessfulLoginResponse_high = "awswaf:managed:aws:atp:aggregate:volumetric:ip:successful_login_response:high",
+  VolumemetricIpSuccessfulLoginResponse_medium = "awswaf:managed:aws:atp:aggregate:volumetric:ip:successful_login_response:medium",
+  VolumemetricIpSuccessfulLoginResponse_low = "awswaf:managed:aws:atp:aggregate:volumetric:ip:successful_login_response:low",
+  VolumetricSession = "awswaf:managed:aws:atp:aggregate:volumetric:session",
+  VolumetricSessionFailedLoginResponseHigh = "awswaf:managed:aws:atp:aggregate:volumetric:session:failed_login_response:high",
+  VolumetricSessionFailedLoginResponseMedium = "awswaf:managed:aws:atp:aggregate:volumetric:session:failed_login_response:medium",
+  VolumetricSessionFailedLoginResponseLow = "awswaf:managed:aws:atp:aggregate:volumetric:session:failed_login_response:low",
+  VolumetricSessionSuccessfulLoginResponseHigh = "awswaf:managed:aws:atp:aggregate:volumetric:session:successful_login_response:high",
+  VolumetricSessionSuccessfulLoginResponseMedium = "awswaf:managed:aws:atp:aggregate:volumetric:session:successful_login_response:medium",
+  VolumetricSessionSuccessfulLoginResponseLow = "awswaf:managed:aws:atp:aggregate:volumetric:session:successful_login_response:low",
+  VolumetricSessiontokenReuseIp = "awswaf:managed:aws:atp:aggregate:volumetric:session:token_reuse:ip",
+  AttributeLongSession = "awswaf:managed:aws:atp:aggregate:attribute:long_session",
+  AttributeCompromisedCredentials = "awswaf:managed:aws:atp:aggregate:attribute:compromised_credentials",
+  AttributeUsernameTraversal = "awswaf:managed:aws:atp:aggregate:attribute:username_traversal",
+  AttributePasswordTraversal = "awswaf:managed:aws:atp:aggregate:attribute:password_traversal",
+  SignalMissingCompromised = "awswaf:managed:aws:atp:signal:credential_compromised",
+  SignalMissingCredential = "awswaf:managed:aws:atp:signal:missing_credential",
+  TokenRejected = "awswaf:managed:token:rejected",
+  TokenAccepted = "awswaf:managed:token:accepted",
+  TokenAbsent = "awswaf:managed:token:absent",
+}
+
+
+/**
+ * Enum for AWSManagedRulesBotControlRuleSet Rules
+ */
+export enum BOT_CONTROL_RULE_SET_RULES {
+  CategoryAdvertising = "CategoryAdvertising",
+  CategoryArchiver = "CategoryArchiver",
+  CategoryContentFetcher = "CategoryContentFetcher",
+  CategoryEmailClient   = "CategoryEmailClient",
+  CategoryHttpLibrary = "CategoryHttpLibrary",
+  CategoryLinkChecker = "CategoryLinkChecker",
+  CategoryMiscellaneous = "CategoryMiscellaneous",
+  CategoryMonitoring = "CategoryMonitoring",
+  CategoryScrapingFramework = "CategoryScrapingFramework",
+  CategorySearchEngine  = "CategorySearchEngine",
+  CategorySecurity = "CategorySecurity",
+  CategorySeo = "CategorySeo",
+  CategorySocialMedia = "CategorySocialMedia",
+  CategoryAI = "CategoryAI",
+  SignalAutomatedBrowser = "SignalAutomatedBrowser",
+  SignalKnownBotDataCenter = "SignalKnownBotDataCenter",
+  SignalNonBrowserUserAgent = "SignalNonBrowserUserAgent",
+  TGT_VolumetricIpTokenAbsent = "TGT_VolumetricIpTokenAbsent",
+  TGT_VolumetricSession = "TGT_VolumetricSession",
+  TGT_SignalAutomatedBrowser = "TGT_SignalAutomatedBrowser",
+  TGT_SignalBrowserInconsistency = "TGT_SignalBrowserInconsistency",
+  TGT_TokenReuseIp = "TGT_TokenReuseIp",
+  TGT_ML_CoordinatedActivityMedium = "TGT_ML_CoordinatedActivityMedium",
+  TGT_ML_CoordinatedActivityHigh = "TGT_ML_CoordinatedActivityHigh",
+}
+
+/**
+ * Enum for AWSManagedRulesBotControlRuleSet Labels
+ */
+export enum BOT_CONTROL_RULE_SET_LABELS {
+  CategoryAdvertising = "awswaf:managed:aws:bot-control:bot:category:advertising",
+  CategoryAi = "awswaf:managed:aws:bot-control:bot:category:ai",
+  CategoryArchiver = "awswaf:managed:aws:bot-control:bot:category:archiver",
+  CategoryContentFetcher = "awswaf:managed:aws:bot-control:bot:category:content_fetcher",
+  CategoryEmailClient = "awswaf:managed:aws:bot-control:bot:category:email_client",
+  CategoryHttpLibrary = "awswaf:managed:aws:bot-control:bot:category:http_library",
+  CategoryLinkChecker = "awswaf:managed:aws:bot-control:bot:category:link_checker",
+  CategoryMiscellaneous = "awswaf:managed:aws:bot-control:bot:category:miscellaneous",
+  CategoryMonitoring = "awswaf:managed:aws:bot-control:bot:category:monitoring",
+  CategoryScrapingFramework = "awswaf:managed:aws:bot-control:bot:category:scraping_framework",
+  CategorySearchEngine = "awswaf:managed:aws:bot-control:bot:category:search_engine",
+  CategorySecurity = "awswaf:managed:aws:bot-control:bot:category:security",
+  CategorySeo = "awswaf:managed:aws:bot-control:bot:category:seo",
+  CategorySocialMedia = "awswaf:managed:aws:bot-control:bot:category:social_media",
+  DeveloperPlatformVerified = "awswaf:managed:aws:bot-control:bot:developer_platform:verified",
+  NameAasaBot = "awswaf:managed:aws:bot-control:bot:name:aasa_bot",
+  NameAcunetix = "awswaf:managed:aws:bot-control:bot:name:acunetix",
+  NameAdidxbot = "awswaf:managed:aws:bot-control:bot:name:adidxbot",
+  NameAdmantx = "awswaf:managed:aws:bot-control:bot:name:admantx",
+  NameAhrefsbot = "awswaf:managed:aws:bot-control:bot:name:ahrefsbot",
+  NameAlexabot = "awswaf:managed:aws:bot-control:bot:name:alexabot",
+  NameAmazonAdbot = "awswaf:managed:aws:bot-control:bot:name:amazon_adbot",
+  NameAmazonbot = "awswaf:managed:aws:bot-control:bot:name:amazonbot",
+  NameApache = "awswaf:managed:aws:bot-control:bot:name:apache",
+  NameAppInsights = "awswaf:managed:aws:bot-control:bot:name:app_insights",
+  NameApplebot = "awswaf:managed:aws:bot-control:bot:name:applebot",
+  NameAxios = "awswaf:managed:aws:bot-control:bot:name:axios",
+  NameBaidu = "awswaf:managed:aws:bot-control:bot:name:baidu",
+  NameBarkrowler = "awswaf:managed:aws:bot-control:bot:name:barkrowler",
+  NameBingbot = "awswaf:managed:aws:bot-control:bot:name:bingbot",
+  NameBitly = "awswaf:managed:aws:bot-control:bot:name:bitly",
+  NameBlexbot = "awswaf:managed:aws:bot-control:bot:name:blexbot",
+  NameBomborabot = "awswaf:managed:aws:bot-control:bot:name:bomborabot",
+  NameBooko = "awswaf:managed:aws:bot-control:bot:name:booko",
+  NameBotify = "awswaf:managed:aws:bot-control:bot:name:botify",
+  NameBrandVerity = "awswaf:managed:aws:bot-control:bot:name:brand_verity",
+  NameBytespider = "awswaf:managed:aws:bot-control:bot:name:bytespider",
+  NameCcbot = "awswaf:managed:aws:bot-control:bot:name:ccbot",
+  NameChatgpt = "awswaf:managed:aws:bot-control:bot:name:chatgpt",
+  NameChatgptUser = "awswaf:managed:aws:bot-control:bot:name:chatgpt_user",
+  NameCheckmarkNetwork = "awswaf:managed:aws:bot-control:bot:name:checkmark_network",
+  NameChromeLighthouse = "awswaf:managed:aws:bot-control:bot:name:chrome_lighthouse",
+  NameClickagy = "awswaf:managed:aws:bot-control:bot:name:clickagy",
+  NameCliqzbot = "awswaf:managed:aws:bot-control:bot:name:cliqzbot",
+  NameCloudflare = "awswaf:managed:aws:bot-control:bot:name:cloudflare",
+  NameCoccoc = "awswaf:managed:aws:bot-control:bot:name:coccoc",
+  NameComodo = "awswaf:managed:aws:bot-control:bot:name:comodo",
+  NameCrawler4j = "awswaf:managed:aws:bot-control:bot:name:crawler4j",
+  NameCriteobot = "awswaf:managed:aws:bot-control:bot:name:criteobot",
+  NameCurl = "awswaf:managed:aws:bot-control:bot:name:curl",
+  NameCxensebot = "awswaf:managed:aws:bot-control:bot:name:cxensebot",
+  NameDatadogSyntheticMonitor = "awswaf:managed:aws:bot-control:bot:name:datadog_synthetic_monitor",
+  NameDataforseobot = "awswaf:managed:aws:bot-control:bot:name:dataforseobot",
+  NameDatanyze = "awswaf:managed:aws:bot-control:bot:name:datanyze",
+  NameDeepcrawl = "awswaf:managed:aws:bot-control:bot:name:deepcrawl",
+  NameDetectify = "awswaf:managed:aws:bot-control:bot:name:detectify",
+  NameDiscordbot = "awswaf:managed:aws:bot-control:bot:name:discordbot",
+  NameDocomo = "awswaf:managed:aws:bot-control:bot:name:docomo",
+  NameDotbot = "awswaf:managed:aws:bot-control:bot:name:dotbot",
+  NameDrupal = "awswaf:managed:aws:bot-control:bot:name:drupal",
+  NameDuckduckbot = "awswaf:managed:aws:bot-control:bot:name:duckduckbot",
+  NameDuckduckgoFaviconsBot = "awswaf:managed:aws:bot-control:bot:name:duckduckgo_favicons_bot",
+  NameEchoboxbot = "awswaf:managed:aws:bot-control:bot:name:echoboxbot",
+  NameEmbedly = "awswaf:managed:aws:bot-control:bot:name:embedly",
+  NameEzooms = "awswaf:managed:aws:bot-control:bot:name:ezooms",
+  NameFacebook = "awswaf:managed:aws:bot-control:bot:name:facebook",
+  NameFacebot = "awswaf:managed:aws:bot-control:bot:name:facebot",
+  NameFeedburner = "awswaf:managed:aws:bot-control:bot:name:feedburner",
+  NameFeedfinder = "awswaf:managed:aws:bot-control:bot:name:feedfinder",
+  NameFeedspot = "awswaf:managed:aws:bot-control:bot:name:feedspot",
+  NameFindlinks = "awswaf:managed:aws:bot-control:bot:name:findlinks",
+  NameFlipboard = "awswaf:managed:aws:bot-control:bot:name:flipboard",
+  NameFreshpingbot = "awswaf:managed:aws:bot-control:bot:name:freshpingbot",
+  NameGarlik = "awswaf:managed:aws:bot-control:bot:name:garlik",
+  NameGenieo = "awswaf:managed:aws:bot-control:bot:name:genieo",
+  NameGetintent = "awswaf:managed:aws:bot-control:bot:name:getintent",
+  NameGoHttp = "awswaf:managed:aws:bot-control:bot:name:go_http",
+  NameGoogleAdsbot = "awswaf:managed:aws:bot-control:bot:name:google_adsbot",
+  NameGoogleAdsense = "awswaf:managed:aws:bot-control:bot:name:google_adsense",
+  NameGoogleApis = "awswaf:managed:aws:bot-control:bot:name:google_apis",
+  NameGoogleAppEngine = "awswaf:managed:aws:bot-control:bot:name:google_app_engine",
+  NameGoogleAppsScript = "awswaf:managed:aws:bot-control:bot:name:google_apps_script",
+  NameGoogleAssociationService = "awswaf:managed:aws:bot-control:bot:name:google_association_service",
+  NameGoogleCommonCrawler = "awswaf:managed:aws:bot-control:bot:name:google_common_crawler",
+  NameGoogleFavicon = "awswaf:managed:aws:bot-control:bot:name:google_favicon",
+  NameGoogleFeedfetcher = "awswaf:managed:aws:bot-control:bot:name:google_feedfetcher",
+  NameGoogleImageproxy = "awswaf:managed:aws:bot-control:bot:name:google_imageproxy",
+  NameGoogleInspectionTool = "awswaf:managed:aws:bot-control:bot:name:google_inspection_tool",
+  NameGoogleMediapartners = "awswaf:managed:aws:bot-control:bot:name:google_mediapartners",
+  NameGoogleOther = "awswaf:managed:aws:bot-control:bot:name:google_other",
+  NameGooglePagerenderer = "awswaf:managed:aws:bot-control:bot:name:google_pagerenderer",
+  NameGooglePublisherCenter = "awswaf:managed:aws:bot-control:bot:name:google_publisher_center",
+  NameGoogleReadAloud = "awswaf:managed:aws:bot-control:bot:name:google_read_aloud",
+  NameGoogleSiteVerification = "awswaf:managed:aws:bot-control:bot:name:google_site_verification",
+  NameGoogleSpecialCaseCrawler = "awswaf:managed:aws:bot-control:bot:name:google_special_case_crawler",
+  NameGoogleStorebot = "awswaf:managed:aws:bot-control:bot:name:google_storebot",
+  NameGoogleUserTriggeredFetcher = "awswaf:managed:aws:bot-control:bot:name:google_user_triggered_fetcher",
+  NameGoogleWebPreview = "awswaf:managed:aws:bot-control:bot:name:google_web_preview",
+  NameGooglebot = "awswaf:managed:aws:bot-control:bot:name:googlebot",
+  NameGoogleweblight = "awswaf:managed:aws:bot-control:bot:name:googleweblight",
+  NameGptbot = "awswaf:managed:aws:bot-control:bot:name:gptbot",
+  NameGrapeshot = "awswaf:managed:aws:bot-control:bot:name:grapeshot",
+  NameGrub = "awswaf:managed:aws:bot-control:bot:name:grub",
+  NameGtmetrix = "awswaf:managed:aws:bot-control:bot:name:gtmetrix",
+  NameGuzzle = "awswaf:managed:aws:bot-control:bot:name:guzzle",
+  NameHarvester = "awswaf:managed:aws:bot-control:bot:name:harvester",
+  NameHatena = "awswaf:managed:aws:bot-control:bot:name:hatena",
+  NameHeritrix = "awswaf:managed:aws:bot-control:bot:name:heritrix",
+  NameHubspot = "awswaf:managed:aws:bot-control:bot:name:hubspot",
+  NameIchiro = "awswaf:managed:aws:bot-control:bot:name:ichiro",
+  NameIframely = "awswaf:managed:aws:bot-control:bot:name:iframely",
+  NameInternetArchive = "awswaf:managed:aws:bot-control:bot:name:internet_archive",
+  NameIsecbot = "awswaf:managed:aws:bot-control:bot:name:isecbot",
+  NameJakarta = "awswaf:managed:aws:bot-control:bot:name:jakarta",
+  NameJava = "awswaf:managed:aws:bot-control:bot:name:java",
+  NameJersey = "awswaf:managed:aws:bot-control:bot:name:jersey",
+  NameLibhttp = "awswaf:managed:aws:bot-control:bot:name:libhttp",
+  NameLibperl = "awswaf:managed:aws:bot-control:bot:name:libperl",
+  NameLinespider = "awswaf:managed:aws:bot-control:bot:name:Linespider",
+  Namelinespider = "awswaf:managed:aws:bot-control:bot:name:linespider",
+  NameLinguee = "awswaf:managed:aws:bot-control:bot:name:linguee",
+  NameLinkchecker = "awswaf:managed:aws:bot-control:bot:name:linkchecker",
+  NameLinkdex = "awswaf:managed:aws:bot-control:bot:name:linkdex",
+  NameLinkedin = "awswaf:managed:aws:bot-control:bot:name:linkedin",
+  NameLinklint = "awswaf:managed:aws:bot-control:bot:name:linklint",
+  NameLinkscan = "awswaf:managed:aws:bot-control:bot:name:linkscan",
+  NameLinkup = "awswaf:managed:aws:bot-control:bot:name:linkup",
+  NameLinkwalker = "awswaf:managed:aws:bot-control:bot:name:linkwalker",
+  NameLivelapbot = "awswaf:managed:aws:bot-control:bot:name:livelapbot",
+  NameLydia = "awswaf:managed:aws:bot-control:bot:name:lydia",
+  NameMagpie = "awswaf:managed:aws:bot-control:bot:name:magpie",
+  NameMailru = "awswaf:managed:aws:bot-control:bot:name:mailru",
+  NameMarfeel = "awswaf:managed:aws:bot-control:bot:name:marfeel",
+  NameMauibot = "awswaf:managed:aws:bot-control:bot:name:mauibot",
+  NameMaverick = "awswaf:managed:aws:bot-control:bot:name:maverick",
+  NameMediatoolkitbot = "awswaf:managed:aws:bot-control:bot:name:mediatoolkitbot",
+  NameMegaindex = "awswaf:managed:aws:bot-control:bot:name:megaindex",
+  NameMicrosoftPreview = "awswaf:managed:aws:bot-control:bot:name:microsoft_preview",
+  NameMiniflux = "awswaf:managed:aws:bot-control:bot:name:miniflux",
+  NameMixrankbot = "awswaf:managed:aws:bot-control:bot:name:mixrankbot",
+  NameMj12bot = "awswaf:managed:aws:bot-control:bot:name:mj12bot",
+  NameMoatbot = "awswaf:managed:aws:bot-control:bot:name:moatbot",
+  NameMojeek = "awswaf:managed:aws:bot-control:bot:name:mojeek",
+  NameMoodlebot = "awswaf:managed:aws:bot-control:bot:name:moodlebot",
+  NameMsnbot = "awswaf:managed:aws:bot-control:bot:name:msnbot",
+  NameNetvibes = "awswaf:managed:aws:bot-control:bot:name:netvibes",
+  NameNewrelicSyntheticMonitor = "awswaf:managed:aws:bot-control:bot:name:newrelic_synthetic_monitor",
+  NameNewspaper = "awswaf:managed:aws:bot-control:bot:name:newspaper",
+  NameNimbostratus = "awswaf:managed:aws:bot-control:bot:name:nimbostratus",
+  NameNode_fetch = "awswaf:managed:aws:bot-control:bot:name:node_fetch",
+  NameOkhttp = "awswaf:managed:aws:bot-control:bot:name:okhttp",
+  NameOutlook = "awswaf:managed:aws:bot-control:bot:name:outlook",
+  NamePandalytics = "awswaf:managed:aws:bot-control:bot:name:pandalytics",
+  NamePaperlibot = "awswaf:managed:aws:bot-control:bot:name:paperlibot",
+  NamePetalbot = "awswaf:managed:aws:bot-control:bot:name:petalbot",
+  NamePhpcrawl = "awswaf:managed:aws:bot-control:bot:name:phpcrawl",
+  NamePingability = "awswaf:managed:aws:bot-control:bot:name:pingability",
+  NamePingdom = "awswaf:managed:aws:bot-control:bot:name:pingdom",
+  NamePinterest = "awswaf:managed:aws:bot-control:bot:name:pinterest",
+  NamePocket = "awswaf:managed:aws:bot-control:bot:name:pocket",
+  NameProctorio = "awswaf:managed:aws:bot-control:bot:name:proctorio",
+  NameProximic = "awswaf:managed:aws:bot-control:bot:name:proximic",
+  NamePrtg = "awswaf:managed:aws:bot-control:bot:name:prtg",
+  NamePsbot = "awswaf:managed:aws:bot-control:bot:name:psbot",
+  NamePython = "awswaf:managed:aws:bot-control:bot:name:python",
+  NamePythonRequests = "awswaf:managed:aws:bot-control:bot:name:python_requests",
+  NamQwantify = "awswaf:managed:aws:bot-control:bot:name:qwantify",
+  NameRedditbot = "awswaf:managed:aws:bot-control:bot:name:redditbot",
+  NameRiddler = "awswaf:managed:aws:bot-control:bot:name:riddler",
+  NameRogerbot = "awswaf:managed:aws:bot-control:bot:name:rogerbot",
+  NameRoute53_health_check = "awswaf:managed:aws:bot-control:bot:name:route53_health_check",
+  NameRuby = "awswaf:managed:aws:bot-control:bot:name:ruby",
+  NameScrapy = "awswaf:managed:aws:bot-control:bot:name:scrapy",
+  NameSeekportbot = "awswaf:managed:aws:bot-control:bot:name:seekportbot",
+  NameSemanticscholarbot = "awswaf:managed:aws:bot-control:bot:name:semanticscholarbot",
+  NameSemrushbot = "awswaf:managed:aws:bot-control:bot:name:semrushbot",
+  NameSentibot = "awswaf:managed:aws:bot-control:bot:name:sentibot",
+  NameSerpstatbot = "awswaf:managed:aws:bot-control:bot:name:serpstatbot",
+  NameSimilarTech = "awswaf:managed:aws:bot-control:bot:name:similar_tech",
+  NameSiteImprove = "awswaf:managed:aws:bot-control:bot:name:site_improve",
+  NameSlackImages = "awswaf:managed:aws:bot-control:bot:name:slack_images",
+  NameSlackbot = "awswaf:managed:aws:bot-control:bot:name:slackbot",
+  NameSnapchat = "awswaf:managed:aws:bot-control:bot:name:snapchat",
+  NameSnoopy = "awswaf:managed:aws:bot-control:bot:name:snoopy",
+  NameSogou = "awswaf:managed:aws:bot-control:bot:name:sogou",
+  NameSteeler = "awswaf:managed:aws:bot-control:bot:name:steeler",
+  NameStudyPartner = "awswaf:managed:aws:bot-control:bot:name:study_partner",
+  NameSumologic = "awswaf:managed:aws:bot-control:bot:name:sumologic",
+  NameSuperfeedr = "awswaf:managed:aws:bot-control:bot:name:superfeedr",
+  NameTaboolabot = "awswaf:managed:aws:bot-control:bot:name:taboolabot",
+  NameTelegram = "awswaf:managed:aws:bot-control:bot:name:telegram",
+  NameTinEye = "awswaf:managed:aws:bot-control:bot:name:tin_eye",
+  NameTinyRss = "awswaf:managed:aws:bot-control:bot:name:tiny_rss",
+  NameTrendictionbot = "awswaf:managed:aws:bot-control:bot:name:trendictionbot",
+  NameTwitter = "awswaf:managed:aws:bot-control:bot:name:twitter",
+  NameUptimerobot = "awswaf:managed:aws:bot-control:bot:name:uptimerobot",
+  NameW3c = "awswaf:managed:aws:bot-control:bot:name:w3c",
+  NameW3cValidationServices = "awswaf:managed:aws:bot-control:bot:name:w3c_validation_services",
+  NameWappalyzer = "awswaf:managed:aws:bot-control:bot:name:wappalyzer",
+  NameWebCopier = "awswaf:managed:aws:bot-control:bot:name:web_copier",
+  NameWget = "awswaf:managed:aws:bot-control:bot:name:wget",
+  NameWhatsapp = "awswaf:managed:aws:bot-control:bot:name:whatsapp",
+  NameWordpressScanner = "awswaf:managed:aws:bot-control:bot:name:wordpress_scanner",
+  NameYacy = "awswaf:managed:aws:bot-control:bot:name:yacy",
+  NameYahoo = "awswaf:managed:aws:bot-control:bot:name:yahoo",
+  NameYahoo_mail = "awswaf:managed:aws:bot-control:bot:name:yahoo_mail",
+  NameYandexbot = "awswaf:managed:aws:bot-control:bot:name:yandexbot",
+  NameYanga = "awswaf:managed:aws:bot-control:bot:name:yanga",
+  NameZyborg = "awswaf:managed:aws:bot-control:bot:name:zyborg",
+  OrganizationGoogle = "awswaf:managed:aws:bot-control:bot:organization:google",
+  OrganizationMicrosoft = "awswaf:managed:aws:bot-control:bot:organization:microsoft",
+  Unverified = "awswaf:managed:aws:bot-control:bot:unverified",
+  UserTriggeredVerified = "awswaf:managed:aws:bot-control:bot:user_triggered:verified",
+  Verified = "awswaf:managed:aws:bot-control:bot:verified",
+  SignalAutomatedBrowser = "awswaf:managed:aws:bot-control:signal:automated_browser",
+  SignalKnownBotDataCenter = "awswaf:managed:aws:bot-control:signal:known_bot_data_center",
+  SignalNonBrowserHeader = "awswaf:managed:aws:bot-control:signal:non_browser_header",
+  SignalNonBrowserUserAgent = "awswaf:managed:aws:bot-control:signal:non_browser_user_agent",
+  TokenRejected = "awswaf:managed:token:rejected",
+  tokenAccepted = "awswaf:managed:token:accepted",
+  TokenAbsent = "awswaf:managed:token:absent",
+  TGT_ML_CoordinatedActivityMedium = "awswaf:managed:aws:bot-control:targeted:aggregate:coordinated_activity:medium",
+  TGT_ML_CoordinatedActivityHigh = "awswaf:managed:aws:bot-control:targeted:aggregate:coordinated_activity:high",
+  TGT_VolumetricIpTokenAbsent = "awswaf:managed:aws:bot-control:targeted:aggregate:volumetric:ip:token_absent",
+  TGT_VolumetricSessionHigh = "awswaf:managed:aws:bot-control:targeted:aggregate:volumetric:session:high",
+  TGT_VolumetricSessiosMedium = "awswaf:managed:aws:bot-control:targeted:aggregate:volumetric:session:medium",
+  TGT_VolumetricSessionLow = "awswaf:managed:aws:bot-control:targeted:aggregate:volumetric:session:low",
+  TGT_TokenReuseIp = "awswaf:managed:aws:bot-control:targeted:aggregate:volumetric:session:token_reuse:ip",
+  TGT_SignalAutomatedBrowser = "awswaf:managed:aws:bot-control:targeted:signal:automated_browser",
+  TGT_SignalBrowserInconsistency = "awswaf:managed:aws:bot-control:targeted:signal:browser_inconsistency",
+}
+
+/**
+ * Enum for AWSManagedRulesAnonymousIpList Rules
+ */
+export enum ANONYMOUS_IP_LIST_RULES {
+  AnonymousIPList = "AnonymousIPList",
+  HostingProviderIPList = "HostingProviderIPList"
+}
+
+/**
+ * Enum for AWSManagedRulesAnonymousIpList Labels
+ */
+export enum ANONYMOUS_IP_LIST_LABELS {
+  AnonymousIPList = "awswaf:managed:aws:anonymous-ip-list:AnonymousIPList",
+  HostingProviderIPList = "awswaf:managed:aws:anonymous-ip-list:HostingProviderIPList",
+}
+
+
+/**
+ * Enum for AWSManagedRulesAmazonIpReputationList Rules
+ */
+export enum AMAZON_IpReputationLIST_RULES {
+  AWSManagedIPReputationList = "AWSManagedIPReputationList",
+  AWSManagedReconnaissanceList  = "AWSManagedReconnaissanceList",
+  AWSManagedIPDDoSList  = "AWSManagedIPDDoSList"
+}
+
+/**
+ * Enum for AWSManagedRulesAmazonIpReputationList Labels
+ */
+export enum AMAZON_IpReputationLIST_LABELS {
+  AWSManagedIPDDoSList = "awswaf:managed:aws:amazon-ip-list:AWSManagedIPDDoSList",
+  AWSManagedIPReputationList = "awswaf:managed:aws:amazon-ip-list:AWSManagedIPReputationList",
+  AWSManagedReconnaissanceList = "awswaf:managed:aws:amazon-ip-list:AWSManagedReconnaissanceList",
+}
+
+/**
+ * Enum for AWSManagedRulesWordPressRuleSet Rules
+ */
+export enum WORDPRESS_RULE_SET_RULES {
+  WordPressExploitableCommands_QUERYSTRING = "WordPressExploitableCommands_QUERYSTRING",
+  WordPressExploitablePaths_URIPATH  = "WordPressExploitablePaths_URIPATH"
+}
+
+/**
+ * Enum for AWSManagedRulesWordPressRuleSet Labels
+ */
+export enum WORDPRESS_RULE_SET_LABELS {
+  WordPressExploitableCommands_QUERYSTRING = "awswaf:managed:aws:wordpress-app:WordPressExploitableCommands_QUERYSTRING",
+  WordPressExploitablePaths_URIPATH = "awswaf:managed:aws:wordpress-app:WordPressExploitablePaths_URIPATH",
+}
+
+/**
+ * Enum for AWSManagedRulesPHPRuleSet Rules
+ */
+export enum PHP_RULE_SET_RULES {
+  PHPHighRiskMethodsVariables_HEADER = "PHPHighRiskMethodsVariables_HEADER",
+  PHPHighRiskMethodsVariables_QUERYSTRING = "PHPHighRiskMethodsVariables_QUERYSTRING",
+  PHPHighRiskMethodsVariables_BODY = "PHPHighRiskMethodsVariables_BODY"
+}
+
+/**
+ * Enum for AWSManagedRulesPHPRuleSet Labels
+ */
+export enum PHP_RULE_SET_LABELS {
+  PHPHighRiskMethodsVariables_HEADER = "awswaf:managed:aws:php-app:PHPHighRiskMethodsVariables_Header",
+  PHPHighRiskMethodsVariables_QUERYSTRING = "awswaf:managed:aws:php-app:PHPHighRiskMethodsVariables_QueryString",
+  PHPHighRiskMethodsVariables_BODY = "awswaf:managed:aws:php-app:PHPHighRiskMethodsVariables_Body",
+}
+
+/**
+ * Enum for AWSManagedRulesWindowsRuleSet Rules
+ */
+export enum WINDOWS_RULE_SET_RULES {
+  WindowsShellCommands_COOKIE = "WindowsShellCommands_COOKIE",
+  WindowsShellCommands_QUERYARGUMENTS = "WindowsShellCommands_QUERYARGUMENTS",
+  WindowsShellCommands_BODY = "WindowsShellCommands_BODY",
+  PowerShellCommands_COOKIE = "PowerShellCommands_COOKIE",
+  PowerShellCommands_QUERYARGUMENTS = "PowerShellCommands_QUERYARGUMENTS",
+  PowerShellCommands_BODY = "PowerShellCommands_BODY"
+}
+
+/**
+ * Enum for AWSManagedRulesWindowsRuleSet Labels
+ */
+export enum WINDOWS_RULE_SET_LABELS {
+  WindowsShellCommands_COOKIE = "awswaf:managed:aws:windows-os:WindowsShellCommands_Cookie",
+  WindowsShellCommands_BODY = "awswaf:managed:aws:windows-os:WindowsShellCommands_Body",
+  PowerShellCommands_COOKIE = "awswaf:managed:aws:windows-os:PowerShellCommands_Cookie",
+  WindowsShellCommands_QUERYARGUMENTS = "awswaf:managed:aws:windows-os:WindowsShellCommands_QueryArguments",
+  PowerShellCommands_QUERYARGUMENTS = "awswaf:managed:aws:windows-os:PowerShellCommands_QueryArguments",
+  PowerShellCommands_BODY = "awswaf:managed:aws:windows-os:PowerShellCommands_Body",
+}
+
+/**
+ * Enum for AWSManagedRulesUnixRuleSet Rules
+ */
+export enum UNIX_RULE_SET_RULES {
+  UNIXShellCommandsVariables_QUERYARGUMENTS = "UNIXShellCommandsVariables_QUERYARGUMENTS",
+  UNIXShellCommandsVariables_BODY = "UNIXShellCommandsVariables_BODY",
+}
+
+/**
+ * Enum for AWSManagedRulesUnixRuleSet Labels
+ */
+export enum UNIX_RULE_SET_LABELS {
+  UNIXShellCommandsVariables_BODY = "awswaf:managed:aws:posix-os:UNIXShellCommandsVariables_BODY",
+  UNIXShellCommandsVariables_QUERYARGUMENTS = "awswaf:managed:aws:posix-os:UNIXShellCommandsVariables_QUERYARGUMENTS",
+}
+
+/**
+ * Enum for AWSManagedRulesLinuxRuleSet Rules
+ */
+export enum LINUX_RULE_SET_RULES {
+  LFI_URIPATH = "LFI_URIPATH",
+  LFI_QUERYSTRING = "LFI_QUERYSTRING",
+  LFI_HEADER  = "LFI_HEADER",
+}
+/**
+ * Enum for AWSManagedRulesLinuxRuleSet Labels
+ */
+export enum LINUX_RULE_SET_LABELS {
+  LFI_QUERYSTRING = "awswaf:managed:aws:linux-os:LFI_QueryString",
+  LFI_URIPATH = "awswaf:managed:aws:linux-os:LFI_URIPath",
+  LFI_HEADER = "awswaf:managed:aws:linux-os:LFI_Header",
+}
+
+/**
+ * Enum for AWSManagedRulesSQLiRuleSet Rules
+ */
+export enum SQLI_RULE_SET_RULES {
+  SQLiExtendedPatterns_QUERYARGUMENTS = "SQLiExtendedPatterns_QUERYARGUMENTS",
+  SQLi_QUERYARGUMENTS = "SQLi_QUERYARGUMENTS",
+  SQLi_BODY = "SQLi_BODY",
+  SQLi_COOKIE = "SQLi_COOKIE",
+  SQLi_URIPATH  = "SQLi_URIPATH",
+}
+/**
+ * Enum for AWSManagedRulesSQLiRuleSet Labels
+ */
+export enum SQLI_RULE_SET_LABELS {
+  SQLi_URIPATH = "awswaf:managed:aws:sql-database:SQLi_URIPath",
+  SQLiExtendedPatterns_QUERYARGUMENTS = "awswaf:managed:aws:sql-database:SQLiExtendedPatterns_QueryArguments",
+  SQLi_QUERYARGUMENTS = "awswaf:managed:aws:sql-database:SQLi_QueryArguments",
+  SQLi_BODY = "awswaf:managed:aws:sql-database:SQLi_Body",
+  SQLi_COOKIE = "awswaf:managed:aws:sql-database:SQLi_Cookie",
+}
+
+/**
+ * Enum for AWSManagedRulesKnownBadInputsRuleSet Rules
+ */
+export enum KNOWN_BAD_INPUTS_RULE_SET_RULES {
+  Log4JRCE_HEADER_RC_COUNT = "Log4JRCE_HEADER_RC_COUNT",
+  Log4JRCE_URIPATH_RC_COUNT = "Log4JRCE_URIPATH_RC_COUNT",
+  Log4JRCE_BODY_RC_COUNT  = "Log4JRCE_BODY_RC_COUNT",
+  Log4JRCE_QUERYSTRING_RC_COUNT = "Log4JRCE_QUERYSTRING_RC_COUNT",
+  Host_localhost_HEADER_RC_COUNT  = "Host_localhost_HEADER_RC_COUNT",
+  JavaDeserializationRCE_HEADER_RC_COUNT  = "JavaDeserializationRCE_HEADER_RC_COUNT",
+  JavaDeserializationRCE_QUERYSTRING_RC_COUNT = "JavaDeserializationRCE_QUERYSTRING_RC_COUNT",
+  JavaDeserializationRCE_URIPATH_RC_COUNT   = "JavaDeserializationRCE_URIPATH_RC_COUNT",
+  JavaDeserializationRCE_BODY_RC_COUNT = "JavaDeserializationRCE_BODY_RC_COUNT",
+  JavaDeserializationRCE_BODY = "JavaDeserializationRCE_BODY",
+  JavaDeserializationRCE_URIPATH = "JavaDeserializationRCE_URIPATH",
+  JavaDeserializationRCE_QUERYSTRING = "JavaDeserializationRCE_QUERYSTRING",
+  JavaDeserializationRCE_HEADER   = "JavaDeserializationRCE_HEADER",
+  Host_localhost_HEADER   = "Host_localhost_HEADER",
+  PROPFIND_METHOD   = "PROPFIND_METHOD",
+  ExploitablePaths_URIPATH  = "ExploitablePaths_URIPATH",
+  Log4JRCE_QUERYSTRING = "Log4JRCE_QUERYSTRING",
+  Log4JRCE_BODY   = "Log4JRCE_BODY",
+  Log4JRCE_URIPATH  = "Log4JRCE_URIPATH",
+  Log4JRCE_HEADER  = "Log4JRCE_HEADER",
+}
+
+/**
+ * Enum for AWSManagedRulesKnownBadInputsRuleSet Labels
+ */
+export enum KNOWN_BAD_INPUTS_RULE_SET_LABELS {
+  Host_localhost_HEADER_RC_COUNT = "awswaf:managed:aws:known-bad-inputs:Host_Localhost_Header_RC_COUNT",
+  JavaDeserializationRCE_QUERYSTRING_RC_COUNT = "awswaf:managed:aws:known-bad-inputs:JavaDeserializationRCE_QueryString_RC_COUNT",
+  Log4JRCE_QUERYSTRING_RC_COUNT = "awswaf:managed:aws:known-bad-inputs:Log4JRCE_QueryString_RC_COUNT",
+  Log4JRCE_BODY_RC_COUNT = "awswaf:managed:aws:known-bad-inputs:Log4JRCE_Body_RC_COUNT",
+  Log4JRCE_URIPATH = "awswaf:managed:aws:known-bad-inputs:Log4JRCE_URIPath",
+  ExploitablePaths_URIPATH = "awswaf:managed:aws:known-bad-inputs:ExploitablePaths_URIPath",
+  JavaDeserializationRCE_BODY = "awswaf:managed:aws:known-bad-inputs:JavaDeserializationRCE_Body",
+  Log4JRCE_QUERYSTRING = "awswaf:managed:aws:known-bad-inputs:Log4JRCE_QueryString",
+  Log4JRCE_URIPATH_RC_COUNT = "awswaf:managed:aws:known-bad-inputs:Log4JRCE_URIPath_RC_COUNT",
+  PROPFIND_METHOD = "awswaf:managed:aws:known-bad-inputs:Propfind_Method",
+  JavaDeserializationRCE_BODY_RC_COUNT = "awswaf:managed:aws:known-bad-inputs:JavaDeserializationRCE_Body_RC_COUNT",
+  JavaDeserializationRCE_HEADER_RC_COUNT = "awswaf:managed:aws:known-bad-inputs:JavaDeserializationRCE_Header_RC_COUNT",
+  Log4JRCE_HEADER_RC_COUNT = "awswaf:managed:aws:known-bad-inputs:Log4JRCE_Header_RC_COUNT",
+  JavaDeserializationRCE_URIPATH = "awswaf:managed:aws:known-bad-inputs:JavaDeserializationRCE_URIPath",
+  Host_localhost_HEADER = "awswaf:managed:aws:known-bad-inputs:Host_Localhost_Header",
+  JavaDeserializationRCE_QUERYSTRING = "awswaf:managed:aws:known-bad-inputs:JavaDeserializationRCE_QueryString",
+  JavaDeserializationRCE_HEADER = "awswaf:managed:aws:known-bad-inputs:JavaDeserializationRCE_Header",
+  JavaDeserializationRCE_URIPATH_RC_COUNT = "awswaf:managed:aws:known-bad-inputs:JavaDeserializationRCE_URIPath_RC_COUNT",
+  Log4JRCE_BODY = "awswaf:managed:aws:known-bad-inputs:Log4JRCE_Body",
+  Log4JRCE_HEADER = "awswaf:managed:aws:known-bad-inputs:Log4JRCE_Header",
+}
+
+/**
+ * Enum for AWSManagedRulesCommonRuleSet Rules
+ */
+export enum COMMON_RULE_SET_RULES {
+  NoUserAgent_HEADER = "NoUserAgent_HEADER",
+  UserAgent_BadBots_HEADER = "UserAgent_BadBots_HEADER",
+  SizeRestrictions_QUERYSTRING = "SizeRestrictions_QUERYSTRING",
+  SizeRestrictions_Cookie_HEADER = "SizeRestrictions_Cookie_HEADER",
+  SizeRestrictions_BODY = "SizeRestrictions_BODY",
+  SizeRestrictions_URIPATH = "SizeRestrictions_URIPATH",
+  EC2MetaDataSSRF_BODY  = "EC2MetaDataSSRF_BODY",
+  EC2MetaDataSSRF_COOKIE  = "EC2MetaDataSSRF_COOKIE",
+  EC2MetaDataSSRF_URIPATH = "EC2MetaDataSSRF_URIPATH",
+  EC2MetaDataSSRF_QUERYARGUMENTS = "EC2MetaDataSSRF_QUERYARGUMENTS",
+  GenericLFI_BODY = "GenericLFI_BODY",
+  GenericLFI_QUERYARGUMENTS = "GenericLFI_QUERYARGUMENTS",
+  GenericLFI_URIPATH  = "GenericLFI_URIPATH",
+  GenericRFI_BODY = "GenericRFI_BODY",
+  GenericRFI_QUERYARGUMENTS = "GenericRFI_QUERYARGUMENTS",
+  GenericRFI_URIPATH  = "GenericRFI_URIPATH",
+  CrossSiteScripting_COOKIE = "CrossSiteScripting_COOKIE",
+  CrossSiteScripting_QUERYARGUMENTS = "CrossSiteScripting_QUERYARGUMENTS",
+  CrossSiteScripting_BODY = "CrossSiteScripting_BODY",
+  CrossSiteScripting_URIPATH  = "CrossSiteScripting_URIPATH",
+  RestrictedExtensions_URIPATH = "RestrictedExtensions_URIPATH",
+  RestrictedExtensions_QUERYARGUMENTS = "RestrictedExtensions_QUERYARGUMENTS",
+}
+
+/**
+ * Enum for AWSManagedRulesCommonRuleSet Labels
+ */
+export enum COMMON_RULE_SET_LABELS {
+  GenericLFI_QUERYARGUMENTS = "awswaf:managed:aws:core-rule-set:GenericLFI_QueryArguments",
+  SizeRestrictions_Cookie_HEADER = "awswaf:managed:aws:core-rule-set:SizeRestrictions_Cookie_Header",
+  EC2MetaDataSSRF_URIPATH = "awswaf:managed:aws:core-rule-set:EC2MetaDataSSRF_URIPath",
+  NoUserAgent_HEADER = "awswaf:managed:aws:core-rule-set:NoUserAgent_Header",
+  EC2MetaDataSSRF_BODY = "awswaf:managed:aws:core-rule-set:EC2MetaDataSSRF_Body",
+  GenericLFI_URIPATH = "awswaf:managed:aws:core-rule-set:GenericLFI_URIPath",
+  GenericRFI_URIPATH = "awswaf:managed:aws:core-rule-set:GenericRFI_URIPath",
+  SizeRestrictions_QUERYSTRING = "awswaf:managed:aws:core-rule-set:SizeRestrictions_QueryString",
+  SizeRestrictions_BODY = "awswaf:managed:aws:core-rule-set:SizeRestrictions_Body",
+  GenericRFI_BODY = "awswaf:managed:aws:core-rule-set:GenericRFI_Body",
+  UserAgent_BadBots_HEADER = "awswaf:managed:aws:core-rule-set:BadBots_Header",
+  SizeRestrictions_URIPATH = "awswaf:managed:aws:core-rule-set:SizeRestrictions_URIPath",
+  GenericLFI_BODY = "awswaf:managed:aws:core-rule-set:GenericLFI_Body",
+  RestrictedExtensions_QUERYARGUMENTS = "awswaf:managed:aws:core-rule-set:RestrictedExtensions_QueryArguments",
+  CrossSiteScripting_URIPATH = "awswaf:managed:aws:core-rule-set:CrossSiteScripting_URIPath",
+  CrossSiteScripting_BODY = "awswaf:managed:aws:core-rule-set:CrossSiteScripting_Body",
+  RestrictedExtensions_URIPATH = "awswaf:managed:aws:core-rule-set:RestrictedExtensions_URIPath",
+  EC2MetaDataSSRF_COOKIE = "awswaf:managed:aws:core-rule-set:EC2MetaDataSSRF_Cookie",
+  GenericRFI_QUERYARGUMENTS = "awswaf:managed:aws:core-rule-set:GenericRFI_QueryArguments",
+  CrossSiteScripting_QUERYARGUMENTS = "awswaf:managed:aws:core-rule-set:CrossSiteScripting_QueryArguments",
+  CrossSiteScripting_COOKIE = "awswaf:managed:aws:core-rule-set:CrossSiteScripting_Cookie",
+  EC2MetaDataSSRF_QUERYARGUMENTS = "awswaf:managed:aws:core-rule-set:EC2MetaDataSSRF_QueryArguments",
+
+}
+
+/**
+ * Enum for AWSManagedRulesAdminProtectionRuleSet Rules
+ */
+export enum ADMIN_PROTECTION_RULE_SET_RULES {
+  AdminProtection_URIPATH = "AdminProtection_URIPATH",
+}
+
+/**
+ * Enum for AWSManagedRulesAdminProtectionRuleSet Labels
+ */
+export enum ADMIN_PROTECTION_RULE_SET_LABELS {
+  AdminProtection_URIPATH = "awswaf:managed:aws:admin-protection:AdminProtection_URIPath",
+}
+
+/**
  * AWS Managed roule Group Vendor
  */
 export enum ManagedRuleGroupVendor {

--- a/lib/types/fms.ts
+++ b/lib/types/fms.ts
@@ -71,6 +71,7 @@ export interface ManagedRuleGroup {
   ruleActionOverrides?: RuleActionOverrideProperty[],
   versionEnabled?: boolean
   latestVersion?: boolean
+  enforceUpdate?:boolean
 }
 export interface Rule {
   name: string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4007,7 +4007,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4070,6 +4071,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4507,7 +4509,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/constructs": {
       "version": "10.2.25",
@@ -5651,6 +5654,7 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -6953,6 +6957,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7669,6 +7674,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7683,6 +7689,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -7693,7 +7700,8 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/sha1": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,30 @@
 {
   "name": "aws-firewall-factory",
-  "version": "4.0.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-firewall-factory",
-      "version": "4.0.0",
+      "version": "4.1.1",
       "dependencies": {
-        "@aws-sdk/client-cloudformation": "^3.398.0",
-        "@aws-sdk/client-cloudwatch": "^3.398.0",
-        "@aws-sdk/client-fms": "^3.398.0",
-        "@aws-sdk/client-pricing": "^3.398.0",
-        "@aws-sdk/client-service-quotas": "^3.398.0",
-        "@aws-sdk/client-shield": "^3.398.0",
-        "@aws-sdk/client-wafv2": "^3.398.0",
+        "@aws-sdk/client-cloudformation": "^3.427.0",
+        "@aws-sdk/client-cloudwatch": "^3.427.0",
+        "@aws-sdk/client-fms": "^3.427.0",
+        "@aws-sdk/client-pricing": "^3.427.0",
+        "@aws-sdk/client-service-quotas": "^3.427.0",
+        "@aws-sdk/client-shield": "^3.427.0",
+        "@aws-sdk/client-wafv2": "^3.427.0",
         "@mhlabs/cfn-diagram": "^1.1.29",
         "@types/aws-lambda": "^8.10.119",
         "@types/lodash": "4.14.178",
-        "aws-cdk-lib": "2.93.0",
+        "@types/uuid": "^9.0.5",
+        "aws-cdk-lib": "2.100.0",
         "aws-lambda": "^1.0.7",
         "cfonts": "^3.2.0",
         "constructs": "10.2.25",
         "lodash": "4.17.21",
+        "table": "^6.8.1",
         "uuid": "^9.0.1"
       },
       "bin": {
@@ -30,10 +32,9 @@
       },
       "devDependencies": {
         "@types/node": "18.16.3",
-        "@types/uuid": "^9.0.4",
-        "@typescript-eslint/eslint-plugin": "6.4.1",
+        "@typescript-eslint/eslint-plugin": "6.7.4",
         "@typescript-eslint/parser": "6.0.0",
-        "aws-cdk": "^2.93.0",
+        "aws-cdk": "2.100.0",
         "eslint": "8.48.0",
         "jest": "29.5.0",
         "ts-jest": "29.1.1",
@@ -170,46 +171,47 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-cloudformation": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.398.0.tgz",
-      "integrity": "sha512-NQAjm0FYmmMT9jn7y2kYpa5MtANwe2c+65IJATXCJC9YqmDxDveZce6YmOpZ3Qflf7Z1J2A7rYAwo0qO35/Zcg==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.427.0.tgz",
+      "integrity": "sha512-Hm1E/b3mIq/6vTJthN8CR+92p73AMLSA8Oe/qso78aUCEYyFL32gjT1fCQFTx0HYyh2x0sbJXSO/jD7FpUR4PQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.398.0",
-        "@aws-sdk/credential-provider-node": "3.398.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
+        "@aws-sdk/client-sts": "3.427.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.5",
+        "@smithy/util-waiter": "^2.0.10",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
@@ -220,53 +222,54 @@
     },
     "node_modules/@aws-sdk/client-cloudformation/node_modules/uuid": {
       "version": "8.3.2",
-      "resolved": "https://repo.entw.bconnect.barmer.de/artifactory/api/npm/npm/uuid/-/uuid-8.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch": {
-      "version": "3.400.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.400.0.tgz",
-      "integrity": "sha512-wQ2Rlyo1YqVGezXHzy3oR2NYBZBT6FK3SRk4DAOqvWA7rquFprrq8vRs4A7NGIL9Gqb38Vjr6iMiJMBc2NzACQ==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.427.0.tgz",
+      "integrity": "sha512-axyu0c53gznAUPIV+9sycDfYRWXRnddm73l1/J5iMboBEelJARhXAc23OMVGAmwoBHHVaziJLdCqHJAS0t8NHg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.398.0",
-        "@aws-sdk/credential-provider-node": "3.398.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
+        "@aws-sdk/client-sts": "3.427.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.5",
+        "@smithy/util-waiter": "^2.0.10",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
@@ -275,44 +278,45 @@
       }
     },
     "node_modules/@aws-sdk/client-fms": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-fms/-/client-fms-3.398.0.tgz",
-      "integrity": "sha512-DZlLSqRSf+vvQBs5D1pybTm3CzyPmn4r17DTx3oUmfN7xrp/E4aRRThPCiMfNtargaV7YyXWOKkxkh35fRik9A==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-fms/-/client-fms-3.427.0.tgz",
+      "integrity": "sha512-FEELiO0g9u+oIpOK/3RJ7CCDJf4lnaG2feVbasgpwfbotpypNt/61iiCwerNzAKS8YbyO3IUmUqxsEXCXap+DA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.398.0",
-        "@aws-sdk/credential-provider-node": "3.398.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
+        "@aws-sdk/client-sts": "3.427.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -321,44 +325,45 @@
       }
     },
     "node_modules/@aws-sdk/client-pricing": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-pricing/-/client-pricing-3.398.0.tgz",
-      "integrity": "sha512-iho+qoDF2/40stRsjLn/Rhle8pNKY6fd2PLqC7JkMmg9CfChptq/wa2CSVxoWa/QmIB9h8Eg4O+Jp6VUTZx4eA==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-pricing/-/client-pricing-3.427.0.tgz",
+      "integrity": "sha512-eo8vJ5N0EnYY9p4Jc9mh81ltFWYuCvpD0qe3uwdABfv7o3FMro5VAImjLr9smm8+YWSl2BYll25Ys4htR0GYhA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.398.0",
-        "@aws-sdk/credential-provider-node": "3.398.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
+        "@aws-sdk/client-sts": "3.427.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -367,44 +372,45 @@
       }
     },
     "node_modules/@aws-sdk/client-service-quotas": {
-      "version": "3.401.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-service-quotas/-/client-service-quotas-3.401.0.tgz",
-      "integrity": "sha512-UIL9mNRN01y2hC3THTyY+ON2Ni2KQy3yVJELkwEfMuALonONFlQGod3/hUUAhhmheBRm3qsfOdnqtLZx37n4BQ==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-service-quotas/-/client-service-quotas-3.427.0.tgz",
+      "integrity": "sha512-FgKnqzZUOtPaxjrO+tyaSDFN4StRWymTNmJMRfX6e6hSioayYqwPCxFoNwx7aHtOaLcK9VnPH864s/Jx7jWPXg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.398.0",
-        "@aws-sdk/credential-provider-node": "3.398.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
+        "@aws-sdk/client-sts": "3.427.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -413,44 +419,45 @@
       }
     },
     "node_modules/@aws-sdk/client-shield": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-shield/-/client-shield-3.398.0.tgz",
-      "integrity": "sha512-CUqIMW+WNWfwVAZe1z9JshOeCMxUKC4I47beDJb5uV2d8r1+Vk3UkF1VNjp5zbK+FOL0feElgbuYzJxX9NNOog==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-shield/-/client-shield-3.427.0.tgz",
+      "integrity": "sha512-rdpmrA/K+hltxue6Sxt3ArnFTKNtQUdQG4r17VVaQCTd1oDWsJCDDZid+SU7vBI/y771dLpB82In0aDsQ9j2NQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.398.0",
-        "@aws-sdk/credential-provider-node": "3.398.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
+        "@aws-sdk/client-sts": "3.427.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -459,41 +466,42 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.398.0.tgz",
-      "integrity": "sha512-CygL0jhfibw4kmWXG/3sfZMFNjcXo66XUuPC4BqZBk8Rj5vFoxp1vZeMkDLzTIk97Nvo5J5Bh+QnXKhub6AckQ==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.427.0.tgz",
+      "integrity": "sha512-sFVFEmsQ1rmgYO1SgrOTxE/MTKpeE4hpOkm1WqhLQK7Ij136vXpjCxjH1JYZiHiUzO1wr9t4ex4dlB5J3VS/Xg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -502,44 +510,45 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.398.0.tgz",
-      "integrity": "sha512-/3Pa9wLMvBZipKraq3AtbmTfXW6q9kyvhwOno64f1Fz7kFb8ijQFMGoATS70B2pGEZTlxkUqJFWDiisT6Q6dFg==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.427.0.tgz",
+      "integrity": "sha512-le2wLJKILyWuRfPz2HbyaNtu5kEki+ojUkTqCU6FPDRrqUvEkaaCBH9Awo/2AtrCfRkiobop8RuTTj6cAnpiJg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.398.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-sdk-sts": "3.398.0",
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-sdk-sts": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
@@ -549,44 +558,45 @@
       }
     },
     "node_modules/@aws-sdk/client-wafv2": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-wafv2/-/client-wafv2-3.398.0.tgz",
-      "integrity": "sha512-9C98uLNuhMCV5BlN9qaxPczgxTYF7P985BCQ5/PwYK44IM+edec2bw4Pjb4+gTzYvEhSqB1RSk9DSDoWPZVSeg==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-wafv2/-/client-wafv2-3.427.0.tgz",
+      "integrity": "sha512-7s9lkKjc9ZF4hmxKusG+VkDPP1pH18Qu6rttGTdgtn41Hn8tZRoOdkyqJfqPxM/Fes6wcRop5u0b36HfbuiQyQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.398.0",
-        "@aws-sdk/credential-provider-node": "3.398.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
+        "@aws-sdk/client-sts": "3.427.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -595,13 +605,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.398.0.tgz",
-      "integrity": "sha512-Z8Yj5z7FroAsR6UVML+XUdlpoqEe9Dnle8c2h8/xWwIC2feTfIBhjLhRVxfbpbM1pLgBSNEcZ7U8fwq5l7ESVQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.425.0.tgz",
+      "integrity": "sha512-J20etnLvMKXRVi5FK4F8yOCNm2RTaQn5psQTGdDEPWJNGxohcSpzzls8U2KcMyUJ+vItlrThr4qwgpHG3i/N0w==",
       "dependencies": {
-        "@aws-sdk/types": "3.398.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -609,19 +619,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.398.0.tgz",
-      "integrity": "sha512-AsK1lStK3nB9Cn6S6ODb1ktGh7SRejsNVQVKX3t5d3tgOaX+aX1Iwy8FzM/ZEN8uCloeRifUGIY9uQFygg5mSw==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.427.0.tgz",
+      "integrity": "sha512-NmH1cO/w98CKMltYec3IrJIIco19wRjATFNiw83c+FGXZ+InJwReqBnruxIOmKTx2KDzd6fwU1HOewS7UjaaaQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.398.0",
-        "@aws-sdk/credential-provider-process": "3.398.0",
-        "@aws-sdk/credential-provider-sso": "3.398.0",
-        "@aws-sdk/credential-provider-web-identity": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
+        "@aws-sdk/credential-provider-env": "3.425.0",
+        "@aws-sdk/credential-provider-process": "3.425.0",
+        "@aws-sdk/credential-provider-sso": "3.427.0",
+        "@aws-sdk/credential-provider-web-identity": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.2.2",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -629,20 +639,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.398.0.tgz",
-      "integrity": "sha512-odmI/DSKfuWUYeDnGTCEHBbC8/MwnF6yEq874zl6+owoVv0ZsYP8qBHfiJkYqrwg7wQ7Pi40sSAPC1rhesGwzg==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.427.0.tgz",
+      "integrity": "sha512-wYYbQ57nKL8OfgRbl8k6uXcdnYml+p3LSSfDUAuUEp1HKlQ8lOXFJ3BdLr5qrk7LhpyppSRnWBmh2c3kWa7ANQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.398.0",
-        "@aws-sdk/credential-provider-ini": "3.398.0",
-        "@aws-sdk/credential-provider-process": "3.398.0",
-        "@aws-sdk/credential-provider-sso": "3.398.0",
-        "@aws-sdk/credential-provider-web-identity": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
+        "@aws-sdk/credential-provider-env": "3.425.0",
+        "@aws-sdk/credential-provider-ini": "3.427.0",
+        "@aws-sdk/credential-provider-process": "3.425.0",
+        "@aws-sdk/credential-provider-sso": "3.427.0",
+        "@aws-sdk/credential-provider-web-identity": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.2.2",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -650,14 +660,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.398.0.tgz",
-      "integrity": "sha512-WrkBL1W7TXN508PA9wRXPFtzmGpVSW98gDaHEaa8GolAPHMPa5t2QcC/z/cFpglzrcVv8SA277zu9Z8tELdZhg==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.425.0.tgz",
+      "integrity": "sha512-YY6tkLdvtb1Fgofp3b1UWO+5vwS14LJ/smGmuGpSba0V7gFJRdcrJ9bcb9vVgAGuMdjzRJ+bUKlLLtqXkaykEw==",
       "dependencies": {
-        "@aws-sdk/types": "3.398.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.2.2",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -665,16 +675,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.398.0.tgz",
-      "integrity": "sha512-2Dl35587xbnzR/GGZqA2MnFs8+kS4wbHQO9BioU0okA+8NRueohNMdrdQmQDdSNK4BfIpFspiZmFkXFNyEAfgw==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.427.0.tgz",
+      "integrity": "sha512-c+tXyS/i49erHs4bAp6vKNYeYlyQ0VNMBgoco0LCn1rL0REtHbfhWMnqDLF6c2n3yIWDOTrQu0D73Idnpy16eA==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.398.0",
-        "@aws-sdk/token-providers": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
+        "@aws-sdk/client-sso": "3.427.0",
+        "@aws-sdk/token-providers": "3.427.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.2.2",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -682,13 +692,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.398.0.tgz",
-      "integrity": "sha512-iG3905Alv9pINbQ8/MIsshgqYMbWx+NDQWpxbIW3W0MkSH3iAqdVpSCteYidYX9G/jv2Um1nW3y360ib20bvNg==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.425.0.tgz",
+      "integrity": "sha512-/0R65TgRzL01JU3SzloivWNwdkbIhr06uY/F5pBHf/DynQqaspKNfdHn6AiozgSVDfwRHFjKBTUy6wvf3QFkuA==",
       "dependencies": {
-        "@aws-sdk/types": "3.398.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -696,13 +706,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.398.0.tgz",
-      "integrity": "sha512-m+5laWdBaxIZK2ko0OwcCHJZJ5V1MgEIt8QVQ3k4/kOkN9ICjevOYmba751pHoTnbOYB7zQd6D2OT3EYEEsUcA==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.425.0.tgz",
+      "integrity": "sha512-E5Gt41LObQ+cr8QnLthwsH3MtVSNXy1AKJMowDr85h0vzqA/FHUkgHyOGntgozzjXT5M0MaSRYxS0xwTR5D4Ew==",
       "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -710,12 +720,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.398.0.tgz",
-      "integrity": "sha512-CiJjW+FL12elS6Pn7/UVjVK8HWHhXMfvHZvOwx/Qkpy340sIhkuzOO6fZEruECDTZhl2Wqn81XdJ1ZQ4pRKpCg==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.425.0.tgz",
+      "integrity": "sha512-INE9XWRXx2f4a/r2vOU0tAmgctVp7nEaEasemNtVBYhqbKLZvr9ndLBSgKGgJ8LIcXAoISipaMuFiqIGkFsm7A==",
       "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/types": "^2.2.2",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -723,13 +733,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.398.0.tgz",
-      "integrity": "sha512-7QpOqPQAZNXDXv6vsRex4R8dLniL0E/80OPK4PPFsrCh9btEyhN9Begh4i1T+5lL28hmYkztLOkTQ2N5J3hgRQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.425.0.tgz",
+      "integrity": "sha512-77gnzJ5b91bgD75L/ugpOyerx6lR3oyS4080X1YI58EzdyBMkDrHM4FbMcY2RynETi3lwXCFzLRyZjWXY1mRlw==",
       "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -737,13 +747,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.398.0.tgz",
-      "integrity": "sha512-+JH76XHEgfVihkY+GurohOQ5Z83zVN1nYcQzwCFnCDTh4dG4KwhnZKG+WPw6XJECocY0R+H0ivofeALHvVWJtQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.425.0.tgz",
+      "integrity": "sha512-JFojrg76oKAoBknnr9EL5N2aJ1mRCtBqXoZYST58GSx8uYdFQ89qS65VNQ8JviBXzsrCNAn4vDhZ5Ch5E6TxGQ==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/types": "^2.2.2",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -751,16 +761,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.398.0.tgz",
-      "integrity": "sha512-O0KqXAix1TcvZBFt1qoFkHMUNJOSgjJTYS7lFTRKSwgsD27bdW2TM2r9R8DAccWFt5Amjkdt+eOwQMIXPGTm8w==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.425.0.tgz",
+      "integrity": "sha512-ZpOfgJHk7ovQ0sSwg3tU4NxFOnz53lJlkJRf7S+wxQALHM0P2MJ6LYBrZaFMVsKiJxNIdZBXD6jclgHg72ZW6Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.398.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^2.0.5",
+        "@smithy/protocol-http": "^3.0.6",
         "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.2.2",
-        "@smithy/util-middleware": "^2.0.0",
+        "@smithy/types": "^2.3.4",
+        "@smithy/util-middleware": "^2.0.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -768,14 +778,29 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.398.0.tgz",
-      "integrity": "sha512-nF1jg0L+18b5HvTcYzwyFgfZQQMELJINFqI0mi4yRKaX7T5a3aGp5RVLGGju/6tAGTuFbfBoEhkhU3kkxexPYQ==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.427.0.tgz",
+      "integrity": "sha512-y9HxYsNvnA3KqDl8w1jHeCwz4P9CuBEtu/G+KYffLeAMBsMZmh4SIkFFCO9wE/dyYg6+yo07rYcnnIfy7WA0bw==",
       "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.425.0.tgz",
+      "integrity": "sha512-u7uv/iUOapIJdRgRkO3wnpYsUgV6ponsZJQgVg/8L+n+Vo5PQL5gAcIuAOwcYSKQPFaeK+KbmByI4SyOK203Vw==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/types": "^2.3.4",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -783,56 +808,79 @@
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "0.1.0-preview.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-0.1.0-preview.1.tgz",
-      "integrity": "sha512-iPglaZZt2uhRpBO0oXww+oK9mtJQvh91o1NuuIOGMBceSou9qzMtGC5NzJzGnooodfwzARx1rgv9myJpcK38Sw==",
+      "version": "3.374.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.374.0.tgz",
+      "integrity": "sha512-r3mNf+GAsnJQGh2nssPIXdOMKSn/6v1vPPWEHC2Dy0uxVdeBRxlJLVGPt4QtlwX2dT2hnIttUh/vY9yuJRP4kg==",
+      "deprecated": "This package has moved to @smithy/shared-ini-file-loader",
       "dependencies": {
-        "tslib": "^1.8.0"
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.1.0.tgz",
+      "integrity": "sha512-S/v33zvCWzFyGZGlsEF0XsZtNNR281UhR7byk3nRfsgw5lGpg51rK/zjMgulM+h6NSuXaFILaYrw1I1v4kMcuA==",
+      "dependencies": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.398.0.tgz",
-      "integrity": "sha512-nrYgjzavGCKJL/48Vt0EL+OlIc5UZLfNGpgyUW9cv3XZwl+kXV0QB+HH0rHZZLfpbBgZ2RBIJR9uD5ieu/6hpQ==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.427.0.tgz",
+      "integrity": "sha512-4E5E+4p8lJ69PBY400dJXF06LUHYx5lkKzBEsYqWWhoZcoftrvi24ltIhUDoGVLkrLcTHZIWSdFAWSos4hXqeg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.398.0",
-        "@aws-sdk/middleware-logger": "3.398.0",
-        "@aws-sdk/middleware-recursion-detection": "3.398.0",
-        "@aws-sdk/middleware-user-agent": "3.398.0",
-        "@aws-sdk/types": "3.398.0",
-        "@aws-sdk/util-endpoints": "3.398.0",
-        "@aws-sdk/util-user-agent-browser": "3.398.0",
-        "@aws-sdk/util-user-agent-node": "3.398.0",
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/hash-node": "^2.0.5",
-        "@smithy/invalid-dependency": "^2.0.5",
-        "@smithy/middleware-content-length": "^2.0.5",
-        "@smithy/middleware-endpoint": "^2.0.5",
-        "@smithy/middleware-retry": "^2.0.5",
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/smithy-client": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.5",
-        "@smithy/util-defaults-mode-node": "^2.0.5",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -841,11 +889,11 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.398.0.tgz",
-      "integrity": "sha512-r44fkS+vsEgKCuEuTV+TIk0t0m5ZlXHNjSDYEUvzLStbbfUFiNus/YG4UCa0wOk9R7VuQI67badsvvPeVPCGDQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.425.0.tgz",
+      "integrity": "sha512-6lqbmorwerN4v+J5dqbHPAsjynI0mkEF+blf+69QTaKKGaxBBVaXgqoqul9RXYcK5MMrrYRbQIMd0zYOoy90kA==",
       "dependencies": {
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -853,11 +901,12 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.398.0.tgz",
-      "integrity": "sha512-Fy0gLYAei/Rd6BrXG4baspCnWTUSd0NdokU1pZh4KlfEAEN1i8SPPgfiO5hLk7+2inqtCmqxVJlfqbMVe9k4bw==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.427.0.tgz",
+      "integrity": "sha512-rSyiAIFF/EVvity/+LWUqoTMJ0a25RAc9iqx0WZ4tf1UjuEXRRXxZEb+jEZg1bk+pY84gdLdx9z5E+MSJCZxNQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.398.0",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/node-config-provider": "^2.0.13",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -876,24 +925,24 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.398.0.tgz",
-      "integrity": "sha512-A3Tzx1tkDHlBT+IgxmsMCHbV8LM7SwwCozq2ZjJRx0nqw3MCrrcxQFXldHeX/gdUMO+0Oocb7HGSnVODTq+0EA==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.425.0.tgz",
+      "integrity": "sha512-22Y9iMtjGcFjGILR6/xdp1qRezlHVLyXtnpEsbuPTiernRCPk6zfAnK/ATH77r02MUjU057tdxVkd5umUBTn9Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/types": "^2.2.2",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.398.0.tgz",
-      "integrity": "sha512-RTVQofdj961ej4//fEkppFf4KXqKGMTCqJYghx3G0C/MYXbg7MGl7LjfNGtJcboRE8pfHHQ/TUWBDA7RIAPPlQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.425.0.tgz",
+      "integrity": "sha512-SIR4F5uQeeVAi8lv4OgRirtdtNi5zeyogTuQgGi9su8F/WP1N6JqxofcwpUY5f8/oJ2UlXr/tx1f09UHfJJzvA==",
       "dependencies": {
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1001,31 +1050,31 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
-      "integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.20.tgz",
+      "integrity": "sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.11.tgz",
-      "integrity": "sha512-lh7RJrtPdhibbxndr6/xx0w8+CVlY5FJZiaSz908Fpy+G0xkBFTvwLcKJFF4PJxVfGhVWNebikpWGnOoC71juQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.0.tgz",
+      "integrity": "sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.10",
-        "@babel/generator": "^7.22.10",
-        "@babel/helper-compilation-targets": "^7.22.10",
-        "@babel/helper-module-transforms": "^7.22.9",
-        "@babel/helpers": "^7.22.11",
-        "@babel/parser": "^7.22.11",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.11",
-        "@babel/types": "^7.22.11",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-module-transforms": "^7.23.0",
+        "@babel/helpers": "^7.23.0",
+        "@babel/parser": "^7.23.0",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.0",
+        "@babel/types": "^7.23.0",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.3",
@@ -1039,12 +1088,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
-    },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -1055,12 +1098,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
-      "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.10",
+        "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -1070,13 +1113,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
-      "integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.5",
+        "@babel/helper-validator-option": "^7.22.15",
         "browserslist": "^4.21.9",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -1095,22 +1138,22 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1129,28 +1172,28 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-      "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
-      "integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+      "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-simple-access": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.5"
+        "@babel/helper-validator-identifier": "^7.22.20"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1202,44 +1245,44 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.11.tgz",
-      "integrity": "sha512-vyOXC8PBWaGc5h7GMsNx68OH33cypkEDJCHvYVVgVbbxJDROYVtexSk0gK5iCF1xNjRIN2s8ai7hwkWDq5szWg==",
+      "version": "7.23.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.1.tgz",
+      "integrity": "sha512-chNpneuK18yW5Oxsr+t553UZzzAs3aZnFm4bxhebsNTeshrC95yA7l5yl7GBAG+JG1rF0F7zzD2EixK9mWSDoA==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.11",
-        "@babel/types": "^7.22.11"
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.0",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
@@ -1319,9 +1362,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.14",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.14.tgz",
-      "integrity": "sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1508,33 +1551,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-      "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/parser": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.11.tgz",
-      "integrity": "sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
+      "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.10",
-        "@babel/generator": "^7.22.10",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.11",
-        "@babel/types": "^7.22.11",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1552,13 +1595,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
-      "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -1609,9 +1652,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
-      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
+      "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1787,16 +1830,16 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.4.tgz",
-      "integrity": "sha512-wNK6gC0Ha9QeEPSkeJedQuTQqxZYnDPuDcDhVuVatRvMkL4D0VTvFVZj+Yuh6caG2aOfzkUZ36KtCmLNtR02hw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^29.6.3",
-        "jest-util": "^29.6.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1804,15 +1847,15 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.4.tgz",
-      "integrity": "sha512-U/vq5ccNTSVgYH7mHnodHmCffGWHJnz/E1BEWlLuK5pM4FZmGfBn/nrJGLjUsSmyx3otCeqc1T31F4y08AMDLg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.4",
-        "@jest/reporters": "^29.6.4",
-        "@jest/test-result": "^29.6.4",
-        "@jest/transform": "^29.6.4",
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
@@ -1820,21 +1863,21 @@
         "ci-info": "^3.2.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^29.6.3",
-        "jest-config": "^29.6.4",
-        "jest-haste-map": "^29.6.4",
-        "jest-message-util": "^29.6.3",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
         "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.6.4",
-        "jest-resolve-dependencies": "^29.6.4",
-        "jest-runner": "^29.6.4",
-        "jest-runtime": "^29.6.4",
-        "jest-snapshot": "^29.6.4",
-        "jest-util": "^29.6.3",
-        "jest-validate": "^29.6.3",
-        "jest-watcher": "^29.6.4",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.3",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
@@ -1851,37 +1894,37 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.4.tgz",
-      "integrity": "sha512-sQ0SULEjA1XUTHmkBRl7A1dyITM9yb1yb3ZNKPX3KlTd6IG7mWUe3e2yfExtC2Zz1Q+mMckOLHmL/qLiuQJrBQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^29.6.4",
+        "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-mock": "^29.6.3"
+        "jest-mock": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.4.tgz",
-      "integrity": "sha512-Warhsa7d23+3X5bLbrbYvaehcgX5TLYhI03JKoedTiI8uJU4IhqYBWF7OSSgUyz4IgLpUYPkK0AehA5/fRclAA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
       "dev": true,
       "dependencies": {
-        "expect": "^29.6.4",
-        "jest-snapshot": "^29.6.4"
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.4.tgz",
-      "integrity": "sha512-FEhkJhqtvBwgSpiTrocquJCdXPsyvNKcl/n7A3u7X4pVoF4bswm11c9d4AV+kfq2Gpv/mM8x7E7DsRvH+djkrg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^29.6.3"
@@ -1891,47 +1934,47 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.4.tgz",
-      "integrity": "sha512-6UkCwzoBK60edXIIWb0/KWkuj7R7Qq91vVInOe3De6DSpaEiqjKcJw4F7XUet24Wupahj9J6PlR09JqJ5ySDHw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.6.3",
-        "jest-mock": "^29.6.3",
-        "jest-util": "^29.6.3"
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.4.tgz",
-      "integrity": "sha512-wVIn5bdtjlChhXAzVXavcY/3PEjf4VqM174BM3eGL5kMxLiZD5CLnbmkEyA1Dwh9q8XjP6E8RwjBsY/iCWrWsA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.4",
-        "@jest/expect": "^29.6.4",
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "jest-mock": "^29.6.3"
+        "jest-mock": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.4.tgz",
-      "integrity": "sha512-sxUjWxm7QdchdrD3NfWKrL8FBsortZeibSJv4XLjESOOjSUOkjQcb0ZHJwfhEGIvBvTluTzfG2yZWZhkrXJu8g==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.6.4",
-        "@jest/test-result": "^29.6.4",
-        "@jest/transform": "^29.6.4",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@jridgewell/trace-mapping": "^0.3.18",
         "@types/node": "*",
@@ -1945,9 +1988,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.6.3",
-        "jest-util": "^29.6.3",
-        "jest-worker": "^29.6.4",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
@@ -1992,12 +2035,12 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.4.tgz",
-      "integrity": "sha512-uQ1C0AUEN90/dsyEirgMLlouROgSY+Wc/JanVVk0OiUKa5UFh7sJpMEM3aoUBAz2BRNvUJ8j3d294WFuRxSyOQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.4",
+        "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
@@ -2007,14 +2050,14 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.4.tgz",
-      "integrity": "sha512-E84M6LbpcRq3fT4ckfKs9ryVanwkaIB0Ws9bw3/yP4seRLg/VaCZ/LgW0MCq5wwk4/iP/qnilD41aj2fsw2RMg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.6.4",
+        "@jest/test-result": "^29.7.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.4",
+        "jest-haste-map": "^29.7.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -2022,9 +2065,9 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.4.tgz",
-      "integrity": "sha512-8thgRSiXUqtr/pPGY/OsyHuMjGyhVnWrFAwoxmIemlBuiMyU1WFs0tXoNxzcr4A4uErs/ABre76SGmrr5ab/AA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -2035,9 +2078,9 @@
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.4",
+        "jest-haste-map": "^29.7.0",
         "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.6.3",
+        "jest-util": "^29.7.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -2113,30 +2156,48 @@
       }
     },
     "node_modules/@mhlabs/aws-sdk-sso": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@mhlabs/aws-sdk-sso/-/aws-sdk-sso-0.0.12.tgz",
-      "integrity": "sha512-AKMoTF8cN5xj/v4BmkDwKnpuQjJkTy6W+NFY5X3/vmycBS+AygRYzyJr8AZ3YIcP3JjOUfqSbqYADFzAdpgGqg==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@mhlabs/aws-sdk-sso/-/aws-sdk-sso-0.0.16.tgz",
+      "integrity": "sha512-2/4NoPr6LdGORmFi2rubeIIcPWJOaghJNH3bRjPuPw6QEY379PKTUDNYbLb65fbtIARLc+GZvd8YtPBt2hNRKw==",
       "dependencies": {
-        "@aws-sdk/shared-ini-file-loader": "0.1.0-preview.1",
+        "@aws-sdk/shared-ini-file-loader": "^3.7.0",
         "open": "^7.1.0",
         "sha1": "^1.1.1"
       }
     },
-    "node_modules/@mhlabs/cfn-diagram": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/@mhlabs/cfn-diagram/-/cfn-diagram-1.1.29.tgz",
-      "integrity": "sha512-JFnZvUhnxTKBhuX4OVSGLY2CKcKy6lAfgkn8LG3GE95GZ6WA6D55Z+vVBc64QxcSRy5xBEKlF07gun7GiwB86g==",
+    "node_modules/@mhlabs/aws-sdk-sso/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "dependencies": {
-        "@mhlabs/aws-sdk-sso": "0.0.12",
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mhlabs/cfn-diagram": {
+      "version": "1.1.36",
+      "resolved": "https://registry.npmjs.org/@mhlabs/cfn-diagram/-/cfn-diagram-1.1.36.tgz",
+      "integrity": "sha512-ArWZiJBcYY7BBbKviQkpaSIPzZ02Jf3rc1VB48eutraM0AeaF98jMdpV8IIxZXQJ5niv1fRgsFU8AGWSvW8Ohw==",
+      "dependencies": {
+        "@mhlabs/aws-sdk-sso": "0.0.16",
         "aws-icons-directory": "^0.0.6",
         "aws-sdk": "^2.808.0",
+        "cli-color": "^2.0.0",
+        "color-convert": "^2.0.1",
         "color-hash": "^1.0.3",
         "commander": "^7.1.0",
-        "inquirer": "^7.1.0",
+        "fast-xml-parser": "^3.20.3",
+        "inquirer": "^8.2.0",
         "jdom": "^3.1.11",
         "jsdom": "^16.4.0",
         "mxgraph": "^4.1.1",
-        "open": "^7.2.1",
+        "open": "^8.4.0",
         "open-in-editor": "^2.2.0",
         "temp-dir": "^2.0.0",
         "yaml-cfn": "^0.2.3"
@@ -2144,6 +2205,21 @@
       "bin": {
         "cfn-dia": "index.js",
         "cfn-diagram": "index.js"
+      }
+    },
+    "node_modules/@mhlabs/cfn-diagram/node_modules/fast-xml-parser": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "dependencies": {
+        "strnum": "^1.0.4"
+      },
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2206,11 +2282,11 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.5.tgz",
-      "integrity": "sha512-byVZ2KWLMPYAZGKjRpniAzLcygJO4ruClZKdJTuB0eCB76ONFTdptBHlviHpAZXknRz7skYWPfcgO9v30A1SyA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.11.tgz",
+      "integrity": "sha512-MSzE1qR2JNyb7ot3blIOT3O3H0Jn06iNDEgHRaqZUwBgx5EG+VIx24Y21tlKofzYryIOcWpIohLrIIyocD6LMA==",
       "dependencies": {
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2218,13 +2294,14 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.5.tgz",
-      "integrity": "sha512-n0c2AXz+kjALY2FQr7Zy9zhYigXzboIh1AuUUVCqFBKFtdEvTwnwPXrTDoEehLiRTUHNL+4yzZ3s+D0kKYSLSg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.14.tgz",
+      "integrity": "sha512-K1K+FuWQoy8j/G7lAmK85o03O89s2Vvh6kMFmzEmiHUoQCRH1rzbDtMnGNiaMHeSeYJ6y79IyTusdRG+LuWwtg==",
       "dependencies": {
-        "@smithy/types": "^2.2.2",
+        "@smithy/node-config-provider": "^2.1.1",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2232,14 +2309,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.5.tgz",
-      "integrity": "sha512-KFcf/e0meFkQNyteJ65f1G19sgUEY1e5zL7hyAEUPz2SEfBmC9B37WyRq87G3MEEsvmAWwCRu7nFFYUKtR3svQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.16.tgz",
+      "integrity": "sha512-tKa2xF+69TvGxJT+lnJpGrKxUuAZDLYXFhqnPEgnHz+psTpkpcB4QRjHj63+uj83KaeFJdTfW201eLZeRn6FfA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/property-provider": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
+        "@smithy/node-config-provider": "^2.1.1",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/types": "^2.3.5",
+        "@smithy/url-parser": "^2.0.11",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2247,34 +2324,34 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.5.tgz",
-      "integrity": "sha512-iqR6OuOV3zbQK8uVs9o+9AxhVk8kW9NAxA71nugwUB+kTY9C35pUd0A5/m4PRT0Y0oIW7W4kgnSR3fdYXQjECw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.11.tgz",
+      "integrity": "sha512-BQCTjxhCYRZIfXapa2LmZSaH8QUBGwMZw7XRN83hrdixbLjIcj+o549zjkedFS07Ve2TlvWUI6BTzP+nv7snBA==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-hex-encoding": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.5.tgz",
-      "integrity": "sha512-EzFoMowdBNy1VqtvkiXgPFEdosIAt4/4bgZ8uiDiUyfhmNXq/3bV+CagPFFBsgFOR/X2XK4zFZHRsoa7PNHVVg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.2.tgz",
+      "integrity": "sha512-K7aRtRuaBjzlk+jWWeyfDTLAmRRvmA4fU8eHUXtjsuEDgi3f356ZE32VD2ssxIH13RCLVZbXMt5h7wHzYiSuVA==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/querystring-builder": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/querystring-builder": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.5.tgz",
-      "integrity": "sha512-mk551hIywBITT+kXruRNXk7f8Fy7DTzBjZJSr/V6nolYKmUHIG3w5QU6nO9qPYEQGKc/yEPtkpdS28ndeG93lA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.11.tgz",
+      "integrity": "sha512-PbleVugN2tbhl1ZoNWVrZ1oTFFas/Hq+s6zGO8B9bv4w/StTriTKA9W+xZJACOj9X7zwfoTLbscM+avCB1KqOQ==",
       "dependencies": {
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2284,11 +2361,11 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.5.tgz",
-      "integrity": "sha512-0wEi+JT0hM+UUwrJVYbqjuGFhy5agY/zXyiN7BNAJ1XoCDjU5uaNSj8ekPWsXd/d4yM6NSe8UbPd8cOc1+3oBQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.11.tgz",
+      "integrity": "sha512-zazq99ujxYv/NOf9zh7xXbNgzoVLsqE0wle8P/1zU/XdhPi/0zohTPKWUzIxjGdqb5hkkwfBkNkl5H+LE0mvgw==",
       "dependencies": {
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
@@ -2304,12 +2381,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.5.tgz",
-      "integrity": "sha512-E7VwV5H02fgZIUGRli4GevBCAPvkyEI/fgl9SU47nPPi3DAAX3nEtUb8xfGbXjOcJ5BdSUoWWZn42tEd/blOqA==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.13.tgz",
+      "integrity": "sha512-Md2kxWpaec3bXp1oERFPQPBhOXCkGSAF7uc1E+4rkwjgw3/tqAXRtbjbggu67HJdwaif76As8AV6XxbD1HzqTQ==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2317,14 +2394,14 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.5.tgz",
-      "integrity": "sha512-tyzDuoNTbsMQCq5Xkc4QOt6e2GACUllQIV8SQ5fc59FtOIV9/vbf58/GxVjZm2o8+MMbdDBANjTDZe/ijZKfyA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.11.tgz",
+      "integrity": "sha512-mCugsvB15up6fqpzUEpMT4CuJmFkEI+KcozA7QMzYguXCaIilyMKsyxgamwmr+o7lo3QdjN0//XLQ9bWFL129g==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.5",
-        "@smithy/types": "^2.2.2",
-        "@smithy/url-parser": "^2.0.5",
-        "@smithy/util-middleware": "^2.0.0",
+        "@smithy/middleware-serde": "^2.0.11",
+        "@smithy/types": "^2.3.5",
+        "@smithy/url-parser": "^2.0.11",
+        "@smithy/util-middleware": "^2.0.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2332,15 +2409,16 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.5.tgz",
-      "integrity": "sha512-ulIfbFyzQTVnJbLjUl1CTSi0etg6tej/ekwaLp0Gn8ybUkDkKYa+uB6CF/m2J5B6meRwyJlsryR+DjaOVyiicg==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.16.tgz",
+      "integrity": "sha512-Br5+0yoiMS0ugiOAfJxregzMMGIRCbX4PYo1kDHtLgvkA/d++aHbnHB819m5zOIAMPvPE7AThZgcsoK+WOsUTA==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/service-error-classification": "^2.0.0",
-        "@smithy/types": "^2.2.2",
-        "@smithy/util-middleware": "^2.0.0",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/node-config-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/service-error-classification": "^2.0.4",
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-middleware": "^2.0.4",
+        "@smithy/util-retry": "^2.0.4",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -2350,18 +2428,18 @@
     },
     "node_modules/@smithy/middleware-retry/node_modules/uuid": {
       "version": "8.3.2",
-      "resolved": "https://repo.entw.bconnect.barmer.de/artifactory/api/npm/npm/uuid/-/uuid-8.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.5.tgz",
-      "integrity": "sha512-in0AA5sous74dOfTGU9rMJBXJ0bDVNxwdXtEt5lh3FVd2sEyjhI+rqpLLRF1E4ixbw3RSEf80hfRpcPdjg4vvQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.11.tgz",
+      "integrity": "sha512-NuxnjMyf4zQqhwwdh0OTj5RqpnuT6HcH5Xg5GrPijPcKzc2REXVEVK4Yyk8ckj8ez1XSj/bCmJ+oNjmqB02GWA==",
       "dependencies": {
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2369,10 +2447,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz",
-      "integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.5.tgz",
+      "integrity": "sha512-bVQU/rZzBY7CbSxIrDTGZYnBWKtIw+PL/cRc9B7etZk1IKSOe0NvKMJyWllfhfhrTeMF6eleCzOihIQympAvPw==",
       "dependencies": {
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2380,13 +2459,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.5.tgz",
-      "integrity": "sha512-LRtjV9WkhONe2lVy+ipB/l1GX60ybzBmFyeRUoLUXWKdnZ3o81jsnbKzMK8hKq8eFSWPk+Lmyx6ZzCQabGeLxg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.1.tgz",
+      "integrity": "sha512-1lF6s1YWBi1LBu2O30tD3jyTgMtuvk/Z1twzXM4GPYe4dmZix4nNREPJIPOcfFikNU2o0eTYP80+izx5F2jIJA==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.5",
-        "@smithy/shared-ini-file-loader": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/shared-ini-file-loader": "^2.2.0",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2394,14 +2473,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.5.tgz",
-      "integrity": "sha512-lZm5DZf4b3V0saUw9WTC4/du887P6cy2fUyQgQQKRRV6OseButyD5yTzeMmXE53CaXJBMBsUvvIQ0hRVxIq56w==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.7.tgz",
+      "integrity": "sha512-PQIKZXlp3awCDn/xNlCSTFE7aYG/5Tx33M05NfQmWYeB5yV1GZZOSz4dXpwiNJYTXb9jPqjl+ueXXkwtEluFFA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.5",
-        "@smithy/protocol-http": "^2.0.5",
-        "@smithy/querystring-builder": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@smithy/abort-controller": "^2.0.11",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/querystring-builder": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2409,11 +2488,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.5.tgz",
-      "integrity": "sha512-cAFSUhX6aiHcmpWfrCLKvwBtgN1F6A0N8qY/8yeSi0LRLmhGqsY1/YTxFE185MCVzYbqBGXVr9TBv4RUcIV4rA==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.12.tgz",
+      "integrity": "sha512-Un/OvvuQ1Kg8WYtoMCicfsFFuHb/TKL3pCA6ZIo/WvNTJTR94RtoRnL7mY4XkkUAoFMyf6KjcQJ76y1FX7S5rw==",
       "dependencies": {
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2421,11 +2500,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.5.tgz",
-      "integrity": "sha512-d2hhHj34mA2V86doiDfrsy2fNTnUOowGaf9hKb0hIPHqvcnShU4/OSc4Uf1FwHkAdYF3cFXTrj5VGUYbEuvMdw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.7.tgz",
+      "integrity": "sha512-HnZW8y+r66ntYueCDbLqKwWcMNWW8o3eVpSrHNluwtBJ/EUWfQHRKSiu6vZZtc6PGfPQWgVfucoCE/C3QufMAA==",
       "dependencies": {
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2433,11 +2512,11 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.5.tgz",
-      "integrity": "sha512-4DCX9krxLzATj+HdFPC3i8pb7XTAWzzKqSw8aTZMjXjtQY+vhe4azMAqIvbb6g7JKwIkmkRAjK6EXO3YWSnJVQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.11.tgz",
+      "integrity": "sha512-b4kEbVMxpmfv2VWUITn2otckTi7GlMteZQxi+jlwedoATOGEyrCJPfRcYQJjbCi3fZ2QTfh3PcORvB27+j38Yg==",
       "dependencies": {
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -2446,11 +2525,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.5.tgz",
-      "integrity": "sha512-C2stCULH0r54KBksv3AWcN8CLS3u9+WsEW8nBrvctrJ5rQTNa1waHkffpVaiKvcW2nP0aIMBPCobD/kYf/q9mA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.11.tgz",
+      "integrity": "sha512-YXe7jhi7s3dQ0Fu9dLoY/gLu6NCyy8tBWJL/v2c9i7/RLpHgKT+uT96/OqZkHizCJ4kr0ZD46tzMjql/o60KLg==",
       "dependencies": {
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2458,19 +2537,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz",
-      "integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.4.tgz",
+      "integrity": "sha512-77506l12I5gxTZqBkx3Wb0RqMG81bMYLaVQ+EqIWFwQDJRs5UFeXogKxSKojCmz1wLUziHZQXm03MBzPQiumQw==",
+      "dependencies": {
+        "@smithy/types": "^2.3.5"
+      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.5.tgz",
-      "integrity": "sha512-Mvtk6FwMtfbKRC4YuSsIqRYp9WTxsSUJVVo2djgyhcacKGMqicHDWSAmgy3sDrKv+G/G6xTZCPwm6pJARtdxVg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.0.tgz",
+      "integrity": "sha512-xFXqs4vAb5BdkzHSRrTapFoaqS4/3m/CGZzdw46fBjYZ0paYuLAoMY60ICCn1FfGirG+PiJ3eWcqJNe4/SkfyA==",
       "dependencies": {
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2478,15 +2560,15 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.5.tgz",
-      "integrity": "sha512-ABIzXmUDXK4n2c9cXjQLELgH2RdtABpYKT+U131e2I6RbCypFZmxIHmIBufJzU2kdMCQ3+thBGDWorAITFW04A==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.11.tgz",
+      "integrity": "sha512-EFVU1dT+2s8xi227l1A9O27edT/GNKvyAK6lZnIZ0zhIHq/jSLznvkk15aonGAM1kmhmZBVGpI7Tt0odueZK9A==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.5",
+        "@smithy/eventstream-codec": "^2.0.11",
         "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.2.2",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.4",
         "@smithy/util-uri-escape": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2496,13 +2578,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.5.tgz",
-      "integrity": "sha512-kCTFr8wfOAWKDzGvfBElc6shHigWtHNhMQ1IbosjC4jOlayFyZMSs2PysKB+Ox/dhQ41KqOzgVjgiQ+PyWqHMQ==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.10.tgz",
+      "integrity": "sha512-2OEmZDiW1Z196QHuQZ5M6cBE8FCSG0H2HADP1G+DY8P3agsvb0YJyfhyKuJbxIQy15tr3eDAK6FOrlbxgKOOew==",
       "dependencies": {
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/types": "^2.2.2",
-        "@smithy/util-stream": "^2.0.5",
+        "@smithy/middleware-stack": "^2.0.5",
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-stream": "^2.0.15",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2510,9 +2592,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.2.tgz",
-      "integrity": "sha512-4PS0y1VxDnELGHGgBWlDksB2LJK8TG8lcvlWxIsgR+8vROI7Ms8h1P4FQUx+ftAX2QZv5g1CJCdhdRmQKyonyw==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.5.tgz",
+      "integrity": "sha512-ehyDt8M9hehyxrLQGoA1BGPou8Js1Ocoh5M0ngDhJMqbFmNK5N6Xhr9/ZExWkyIW8XcGkiMPq3ZUEE0ScrhbuQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2521,12 +2603,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.5.tgz",
-      "integrity": "sha512-OdMBvZhpckQSkugCXNJQCvqJ71wE7Ftxce92UOQLQ9pwF6hoS5PLL7wEfpnuEXtStzBqJYkzu1C1ZfjuFGOXAA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.11.tgz",
+      "integrity": "sha512-h89yXMCCF+S5k9XIoKltMIWTYj+FcEkU/IIFZ6RtE222fskOTL4Iak6ZRG+ehSvZDt8yKEcxqheTDq7JvvtK3g==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@smithy/querystring-parser": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
@@ -2585,12 +2667,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.5.tgz",
-      "integrity": "sha512-yciP6TPttLsj731aHTvekgyuCGXQrEAJibEwEWAh3kzaDsfGAVCuZSBlyvC2Dl3TZmHKCOQwHV8mIE7KQCTPuQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.14.tgz",
+      "integrity": "sha512-NupG7SWUucm3vJrvlpt9jG1XeoPJphjcivgcUUXhDJbUPy4F04LhlTiAhWSzwlCNcF8OJsMvZ/DWbpYD3pselw==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/smithy-client": "^2.1.10",
+        "@smithy/types": "^2.3.5",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -2599,15 +2682,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.5.tgz",
-      "integrity": "sha512-M07t99rWasXt+IaDZDyP3BkcoEm/mgIE1RIMASrE49LKSNxaVN7PVcgGc77+4uu2kzBAyqJKy79pgtezuknyjQ==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.18.tgz",
+      "integrity": "sha512-+3jMom/b/Cdp21tDnY4vKu249Al+G/P0HbRbct7/aSZDlROzv1tksaYukon6UUv7uoHn+/McqnsvqZHLlqvQ0g==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.5",
-        "@smithy/credential-provider-imds": "^2.0.5",
-        "@smithy/node-config-provider": "^2.0.5",
-        "@smithy/property-provider": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@smithy/config-resolver": "^2.0.14",
+        "@smithy/credential-provider-imds": "^2.0.16",
+        "@smithy/node-config-provider": "^2.1.1",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/smithy-client": "^2.1.10",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2626,10 +2710,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.0.tgz",
-      "integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.4.tgz",
+      "integrity": "sha512-Pbu6P4MBwRcjrLgdTR1O4Y3c0sTZn2JdOiJNcgL7EcIStcQodj+6ZTXtbyU/WTEU3MV2NMA10LxFc3AWHZ3+4A==",
       "dependencies": {
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2637,11 +2722,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.0.tgz",
-      "integrity": "sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.4.tgz",
+      "integrity": "sha512-b+n1jBBKc77C1E/zfBe1Zo7S9OXGBiGn55N0apfhZHxPUP/fMH5AhFUUcWaJh7NAnah284M5lGkBKuhnr3yK5w==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.0.0",
+        "@smithy/service-error-classification": "^2.0.4",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2649,13 +2735,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.5.tgz",
-      "integrity": "sha512-ylx27GwI05xLpYQ4hDIfS15vm+wYjNN0Sc2P0FxuzgRe8v0BOLHppGIQ+Bezcynk8C9nUzsUue3TmtRhjut43g==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.15.tgz",
+      "integrity": "sha512-A/hkYJPH2N5MCWYvky4tTpQihpYAEzqnUfxDyG3L/yMndy/2sLvxnyQal9Opuj1e9FiKSTeMyjnU9xxZGs0mRw==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.0.5",
-        "@smithy/node-http-handler": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@smithy/fetch-http-handler": "^2.2.2",
+        "@smithy/node-http-handler": "^2.1.7",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",
@@ -2690,12 +2776,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.5.tgz",
-      "integrity": "sha512-1lkkUmI/bhaDX+LIT3RiUNAn+NzPmsWjE7beMq0oQ3H1/CffaILIN67riDA0aE1YBj6xll7uWMIy4tJqc+peXw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.11.tgz",
+      "integrity": "sha512-8SJWUl9O1YhjC77EccgltI3q4XZQp3vp9DGEW6o0OdkUcwqm/H4qOLnMkA2n+NDojuM5Iia2jWoCdbluIiG7TA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.5",
-        "@smithy/types": "^2.2.2",
+        "@smithy/abort-controller": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2735,14 +2821,14 @@
       "dev": true
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.119",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.119.tgz",
-      "integrity": "sha512-Vqm22aZrCvCd6I5g1SvpW151jfqwTzEZ7XJ3yZ6xaZG31nUEOEyzzVImjRcsN8Wi/QyPxId/x8GTtgIbsy8kEw=="
+      "version": "8.10.124",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.124.tgz",
+      "integrity": "sha512-PHqK0SuAkFS3tZjceqRXecxxrWIN3VqTicuialtK2wZmvBy7H9WGc3u3+wOgaZB7N8SpSXDpWk9qa7eorpTStg=="
     },
     "node_modules/@types/babel__core": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
-      "integrity": "sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.2.tgz",
+      "integrity": "sha512-pNpr1T1xLUc2l3xJKuPtsEky3ybxN3m4fJkknfIpTCTfIZCDW57oAg+EfCgIIp2rvCe0Wn++/FfodDS4YXxBwA==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -2753,18 +2839,18 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
-      "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.5.tgz",
+      "integrity": "sha512-h9yIuWbJKdOPLJTbmSpPzkF67e659PbQDba7ifWm5BJ8xTv+sDmS7rFmywkWOvXedGTivCdeGSIIX8WLcRTz8w==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
     },
     "node_modules/@types/babel__template": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
-      "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.2.tgz",
+      "integrity": "sha512-/AVzPICMhMOMYoSx9MoKpGDKdBRsIXMNByh1PXSZoa+v6ZoLa8xxtsT/uLQ/NJm0XVAWl/BvId4MlDeXJaeIZQ==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -2772,18 +2858,18 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.1.tgz",
-      "integrity": "sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.2.tgz",
+      "integrity": "sha512-ojlGK1Hsfce93J0+kn3H5R73elidKUaZonirN33GSmgTUMpzI/MIFfSpF3haANe3G1bEBS9/9/QEqwTzwqFsKw==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
     },
     "node_modules/@types/graceful-fs": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
-      "integrity": "sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.7.tgz",
+      "integrity": "sha512-MhzcwU8aUygZroVwL2jeYk6JisJrPl/oov/gsgGCue9mkgl9wjGbzReYQClxiUgFDnib9FuHqTndccKeZKxTRw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -2796,27 +2882,27 @@
       "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-gPQuzaPR5h/djlAv2apEG1HVOyj1IUs7GpfMZixU0/0KXT3pm64ylHuMUI1/Akh+sq/iikxg6Z2j+fcMDXaaTQ==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
     },
     "node_modules/@types/istanbul-reports": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-kv43F9eb3Lhj+lr/Hn6OcLCs/sSM8bt+fIaP11rCYngfV6NVjzWXJ17owQtDQTL9tQ8WSLUrGsSJ6rJz0F1w1A==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
       "dev": true
     },
     "node_modules/@types/lodash": {
@@ -2831,9 +2917,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -2843,37 +2929,36 @@
       "dev": true
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.4",
-      "resolved": "https://repo.entw.bconnect.barmer.de/artifactory/api/npm/npm/@types/uuid/-/uuid-9.0.4.tgz",
-      "integrity": "sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==",
-      "dev": true
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.5.tgz",
+      "integrity": "sha512-xfHdwa1FMJ082prjSJpoEI57GZITiQz10r3vEJCHa2khEFQjKy91aWKz6+zybzssCvXUwE1LQWgWVwZ4nYUvHQ=="
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.24",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
-      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+      "version": "17.0.28",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
+      "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "node_modules/@types/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.1.tgz",
-      "integrity": "sha512-3F5PtBzUW0dYlq77Lcqo13fv+58KDwUib3BddilE8ajPJT+faGgxmI9Sw+I8ZS22BYwoir9ZhNXcLi+S+I2bkw==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.4.tgz",
+      "integrity": "sha512-DAbgDXwtX+pDkAHwiGhqP3zWUGpW49B7eqmgpPtg+BKJXwdct79ut9+ifqOFPJGClGKSHXn2PTBatCnldJRUoA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.4.1",
-        "@typescript-eslint/type-utils": "6.4.1",
-        "@typescript-eslint/utils": "6.4.1",
-        "@typescript-eslint/visitor-keys": "6.4.1",
+        "@typescript-eslint/scope-manager": "6.7.4",
+        "@typescript-eslint/type-utils": "6.7.4",
+        "@typescript-eslint/utils": "6.7.4",
+        "@typescript-eslint/visitor-keys": "6.7.4",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -2961,13 +3046,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.1.tgz",
-      "integrity": "sha512-p/OavqOQfm4/Hdrr7kvacOSFjwQ2rrDVJRPxt/o0TOWdFnjJptnjnZ+sYDR7fi4OimvIuKp+2LCkc+rt9fIW+A==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.4.tgz",
+      "integrity": "sha512-SdGqSLUPTXAXi7c3Ob7peAGVnmMoGzZ361VswK2Mqf8UOYcODiYvs8rs5ILqEdfvX1lE7wEZbLyELCW+Yrql1A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.1",
-        "@typescript-eslint/visitor-keys": "6.4.1"
+        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/visitor-keys": "6.7.4"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2978,9 +3063,9 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/types": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
-      "integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.4.tgz",
+      "integrity": "sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2991,13 +3076,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.1.tgz",
-      "integrity": "sha512-7ON8M8NXh73SGZ5XvIqWHjgX2f+vvaOarNliGhjrJnv1vdjG0LVIz+ToYfPirOoBi56jxAKLfsLm40+RvxVVXA==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.4.tgz",
+      "integrity": "sha512-n+g3zi1QzpcAdHFP9KQF+rEFxMb2KxtnJGID3teA/nxKHOVi3ylKovaqEzGBbVY2pBttU6z85gp0D00ufLzViQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.4.1",
-        "@typescript-eslint/utils": "6.4.1",
+        "@typescript-eslint/typescript-estree": "6.7.4",
+        "@typescript-eslint/utils": "6.7.4",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -3018,9 +3103,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
-      "integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.4.tgz",
+      "integrity": "sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -3031,13 +3116,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.1.tgz",
-      "integrity": "sha512-xF6Y7SatVE/OyV93h1xGgfOkHr2iXuo8ip0gbfzaKeGGuKiAnzS+HtVhSPx8Www243bwlW8IF7X0/B62SzFftg==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.4.tgz",
+      "integrity": "sha512-ty8b5qHKatlNYd9vmpHooQz3Vki3gG+3PchmtsA4TgrZBKWHNjWfkQid7K7xQogBqqc7/BhGazxMD5vr6Ha+iQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.1",
-        "@typescript-eslint/visitor-keys": "6.4.1",
+        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/visitor-keys": "6.7.4",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -3115,17 +3200,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.1.tgz",
-      "integrity": "sha512-F/6r2RieNeorU0zhqZNv89s9bDZSovv3bZQpUNOmmQK1L80/cV4KEu95YUJWi75u5PhboFoKUJBnZ4FQcoqhDw==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.4.tgz",
+      "integrity": "sha512-PRQAs+HUn85Qdk+khAxsVV+oULy3VkbH3hQ8hxLRJXWBEd7iI+GbQxH5SEUSH7kbEoTp6oT1bOwyga24ELALTA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.4.1",
-        "@typescript-eslint/types": "6.4.1",
-        "@typescript-eslint/typescript-estree": "6.4.1",
+        "@typescript-eslint/scope-manager": "6.7.4",
+        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/typescript-estree": "6.7.4",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -3140,9 +3225,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
-      "integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.4.tgz",
+      "integrity": "sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -3153,13 +3238,13 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.1.tgz",
-      "integrity": "sha512-xF6Y7SatVE/OyV93h1xGgfOkHr2iXuo8ip0gbfzaKeGGuKiAnzS+HtVhSPx8Www243bwlW8IF7X0/B62SzFftg==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.4.tgz",
+      "integrity": "sha512-ty8b5qHKatlNYd9vmpHooQz3Vki3gG+3PchmtsA4TgrZBKWHNjWfkQid7K7xQogBqqc7/BhGazxMD5vr6Ha+iQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.1",
-        "@typescript-eslint/visitor-keys": "6.4.1",
+        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/visitor-keys": "6.7.4",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -3180,12 +3265,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.1.tgz",
-      "integrity": "sha512-y/TyRJsbZPkJIZQXrHfdnxVnxyKegnpEvnRGNam7s3TRR2ykGefEWOhaef00/UUN3IZxizS7BTO3svd3lCOJRQ==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.4.tgz",
+      "integrity": "sha512-pOW37DUhlTZbvph50x5zZCkFn3xzwkGtNoJHzIM3svpiSkJzwOYr/kVBaXmf+RAQiUDs1AHEZVNPg6UJCJpwRA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/types": "6.7.4",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -3197,9 +3282,9 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
-      "integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.4.tgz",
+      "integrity": "sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -3372,6 +3457,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3389,9 +3482,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.93.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.93.0.tgz",
-      "integrity": "sha512-C0o7rzlXbQ3othvQ9uZamRwr741MSX/9eZ74zNJvpkX5Eitx/XoQYwUHeD+cbb4lKHMi7m2SwJfx3yOEkpu9OQ==",
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.100.0.tgz",
+      "integrity": "sha512-Gt/4wPuEiBYw2tl0+cN0EbLxxJEvltcJxSQAcVHgNbqvDj49KUJ/oCbZ335dF0gK/hrVVb70xfNiYbBSPOsmvg==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -3404,9 +3497,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.93.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.93.0.tgz",
-      "integrity": "sha512-kKbcKkts272Ju5xjGKI3pXTOpiJxW4OQbDF8Vmw/NIkkuJLo8GlRCFfeOfoN/hilvlYQgENA67GCgSWccbvu7w==",
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.100.0.tgz",
+      "integrity": "sha512-oWDPcbdqD69wDIUvcGdbDxmKcDfkCg515wf8JkiQLnhAI/AFyKAVTEWhbSUi00lvJQNUjX8Mal2lbKlCRA4hjQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -3768,9 +3861,9 @@
       "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
     },
     "node_modules/aws-sdk": {
-      "version": "2.1448.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1448.0.tgz",
-      "integrity": "sha512-15r8YKdAAXLgtPfQTAzD/qNxxgndF1SMEw6F+mXvLxZrLkG4BHnzOW2g2sQc3C2qG5yqCb3K6R+OrjbvGOAmdQ==",
+      "version": "2.1472.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1472.0.tgz",
+      "integrity": "sha512-U7kAHRbvTy753IXKV8Oom/AqlqnsbXG+Kw5gRbKi6VcsZ3hR/EpNMzdRXTWO5U415bnLWGo8WAqIz67PIaaKsw==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -3796,12 +3889,12 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.4.tgz",
-      "integrity": "sha512-meLj23UlSLddj6PC+YTOFRgDAtjnZom8w/ACsrx0gtPtv5cJZk0A5Unk5bV4wixD7XaPCN1fQvpww8czkZURmw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^29.6.4",
+        "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-preset-jest": "^29.6.3",
@@ -3914,8 +4007,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3936,6 +4028,39 @@
         }
       ]
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -3945,7 +4070,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3969,9 +4093,9 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "node_modules/browserslist": {
-      "version": "4.21.10",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "dev": true,
       "funding": [
         {
@@ -3988,10 +4112,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001517",
-        "electron-to-chromium": "^1.4.477",
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
         "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.11"
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4068,9 +4192,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001525",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
-      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
+      "version": "1.0.30001547",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001547.tgz",
+      "integrity": "sha512-W7CrtIModMAxobGhz8iXmDfuJiiKg1WADMO/9x7/CLNin5cpSbuBjooyoIUVB5eyCc36QuTVlkVa1iB2S5+/eA==",
       "dev": true,
       "funding": [
         {
@@ -4151,9 +4275,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "dev": true,
       "funding": [
         {
@@ -4240,6 +4364,21 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/cli-color": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.3.tgz",
+      "integrity": "sha512-OkoZnxyC4ERN3zLzZaY9Emb7f/MhBOIpePv0Ycok0fJYT+Ouo00UBEIwsVsr0yoow++n5YWlSUgST9GKhNHiRQ==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.61",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.15",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -4249,6 +4388,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
+      "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-width": {
@@ -4288,6 +4438,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/co": {
@@ -4349,8 +4507,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/constructs": {
       "version": "10.2.25",
@@ -4365,6 +4522,27 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -4414,6 +4592,15 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+    },
+    "node_modules/d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dependencies": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
     },
     "node_modules/data-urls": {
       "version": "2.0.0",
@@ -4476,6 +4663,25 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/define-property": {
@@ -4568,9 +4774,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.506",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.506.tgz",
-      "integrity": "sha512-xxGct4GPAKSRlrLBtJxJFYy74W11zX6PO9GyHgl/U+2s3Dp0ZEwAklDfNHXOWcvH7zWMpsmgbR0ggEuaYAVvHA==",
+      "version": "1.4.548",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.548.tgz",
+      "integrity": "sha512-R77KD6mXv37DOyKLN/eW1rGS61N6yHOfapNSX9w+y9DdPG83l9Gkuv7qkCFZ4Ta4JPhrjgQfYbv4Y3TnM1Hi2Q==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4597,6 +4803,50 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
       }
     },
     "node_modules/escalade": {
@@ -4809,6 +5059,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
     "node_modules/events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -4850,20 +5109,33 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.4.tgz",
-      "integrity": "sha512-F2W2UyQ8XYyftHT57dtfg8Ue3X5qLgm2sSug0ivvLRH/VKNRL/pDxg/TH7zVzbQB0tu80clNFy6LU7OS/VSEKA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "^29.6.4",
+        "@jest/expect-utils": "^29.7.0",
         "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.6.4",
-        "jest-message-util": "^29.6.3",
-        "jest-util": "^29.6.3"
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
+    },
+    "node_modules/ext/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -4881,8 +5153,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -5026,12 +5297,12 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
-      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
+      "integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
       "dev": true,
       "dependencies": {
-        "flatted": "^3.2.7",
+        "flatted": "^3.2.9",
         "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
@@ -5040,9 +5311,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
     "node_modules/for-each": {
@@ -5182,9 +5453,9 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/globals": {
-      "version": "13.21.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+      "version": "13.23.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
+      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -5239,12 +5510,9 @@
       "dev": true
     },
     "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -5383,7 +5651,6 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5448,26 +5715,28 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
       "dependencies": {
         "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.1",
         "cli-cursor": "^3.1.0",
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
         "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
+        "rxjs": "^7.5.5",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
+        "through": "^2.3.6",
+        "wrap-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/is-accessor-descriptor": {
@@ -5620,6 +5889,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5642,6 +5919,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -5667,6 +5949,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -5701,9 +5994,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.0.tgz",
-      "integrity": "sha512-x58orMzEVfzPUKqlbLd1hXCnySCxKdDKa6Rjg97CwuLLRI4g3FHTdnExu1OqffVFay6zeMW+T6/DowFLndWnIw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
+      "integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -5801,13 +6094,13 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.6.3.tgz",
-      "integrity": "sha512-G5wDnElqLa4/c66ma5PG9eRjE342lIbF6SUnTJi26C3J28Fv2TVY2rOyKB9YGbSA5ogwevgmxc4j4aVjrEK6Yg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
       "dev": true,
       "dependencies": {
         "execa": "^5.0.0",
-        "jest-util": "^29.6.3",
+        "jest-util": "^29.7.0",
         "p-limit": "^3.1.0"
       },
       "engines": {
@@ -5815,28 +6108,28 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.4.tgz",
-      "integrity": "sha512-YXNrRyntVUgDfZbjXWBMPslX1mQ8MrSG0oM/Y06j9EYubODIyHWP8hMUbjbZ19M3M+zamqEur7O80HODwACoJw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.4",
-        "@jest/expect": "^29.6.4",
-        "@jest/test-result": "^29.6.4",
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^1.0.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.6.3",
-        "jest-matcher-utils": "^29.6.4",
-        "jest-message-util": "^29.6.3",
-        "jest-runtime": "^29.6.4",
-        "jest-snapshot": "^29.6.4",
-        "jest-util": "^29.6.3",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.6.3",
+        "pretty-format": "^29.7.0",
         "pure-rand": "^6.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
@@ -5846,22 +6139,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.4.tgz",
-      "integrity": "sha512-+uMCQ7oizMmh8ZwRfZzKIEszFY9ksjjEQnTEMTaL7fYiL3Kw4XhqT9bYh+A4DQKUb67hZn2KbtEnDuHvcgK4pQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.6.4",
-        "@jest/test-result": "^29.6.4",
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
         "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^29.6.4",
-        "jest-util": "^29.6.3",
-        "jest-validate": "^29.6.3",
-        "prompts": "^2.0.1",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
         "yargs": "^17.3.1"
       },
       "bin": {
@@ -5880,31 +6172,31 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.4.tgz",
-      "integrity": "sha512-JWohr3i9m2cVpBumQFv2akMEnFEPVOh+9L2xIBJhJ0zOaci2ZXuKJj0tgMKQCBZAKA09H049IR4HVS/43Qb19A==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.6.4",
+        "@jest/test-sequencer": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "babel-jest": "^29.6.4",
+        "babel-jest": "^29.7.0",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.6.4",
-        "jest-environment-node": "^29.6.4",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
         "jest-get-type": "^29.6.3",
         "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.6.4",
-        "jest-runner": "^29.6.4",
-        "jest-util": "^29.6.3",
-        "jest-validate": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^29.6.3",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -5925,24 +6217,24 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.4.tgz",
-      "integrity": "sha512-9F48UxR9e4XOEZvoUXEHSWY4qC4zERJaOfrbBg9JpbJOO43R1vN76REt/aMGZoY6GD5g84nnJiBIVlscegefpw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
         "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.6.3"
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-docblock": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.6.3.tgz",
-      "integrity": "sha512-2+H+GOTQBEm2+qFSQ7Ma+BvyV+waiIFxmZF5LdpBsAEjWX8QYjSCa4FrkIYtbfXUJJJnFCYrOtt6TZ+IAiTjBQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "dev": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -5952,33 +6244,33 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.6.3.tgz",
-      "integrity": "sha512-KoXfJ42k8cqbkfshW7sSHcdfnv5agDdHCPA87ZBdmHP+zJstTJc0ttQaJ/x7zK6noAL76hOuTIJ6ZkQRS5dcyg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
         "jest-get-type": "^29.6.3",
-        "jest-util": "^29.6.3",
-        "pretty-format": "^29.6.3"
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.4.tgz",
-      "integrity": "sha512-i7SbpH2dEIFGNmxGCpSc2w9cA4qVD+wfvg2ZnfQ7XVrKL0NA5uDVBIiGH8SR4F0dKEv/0qI5r+aDomDf04DpEQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.4",
-        "@jest/fake-timers": "^29.6.4",
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-mock": "^29.6.3",
-        "jest-util": "^29.6.3"
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5994,9 +6286,9 @@
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.4.tgz",
-      "integrity": "sha512-12Ad+VNTDHxKf7k+M65sviyynRoZYuL1/GTuhEVb8RYsNSNln71nANRb/faSyWvx0j+gHcivChXHIoMJrGYjog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -6006,8 +6298,8 @@
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.6.3",
-        "jest-worker": "^29.6.4",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -6019,37 +6311,37 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.3.tgz",
-      "integrity": "sha512-0kfbESIHXYdhAdpLsW7xdwmYhLf1BRu4AA118/OxFm0Ho1b2RcTmO4oF6aAMaxpxdxnJ3zve2rgwzNBD4Zbm7Q==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.6.3"
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.4.tgz",
-      "integrity": "sha512-KSzwyzGvK4HcfnserYqJHYi7sZVqdREJ9DMPAKVbS98JsIAvumihaNUbjrWw0St7p9IY7A9UskCW5MYlGmBQFQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.6.4",
+        "jest-diff": "^29.7.0",
         "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.6.3"
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.3.tgz",
-      "integrity": "sha512-FtzaEEHzjDpQp51HX4UMkPZjy46ati4T5pEMyM6Ik48ztu4T9LQplZ6OsimHx7EuM9dfEh5HJa6D3trEftu3dA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -6058,7 +6350,7 @@
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.3",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -6067,14 +6359,14 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.3.tgz",
-      "integrity": "sha512-Z7Gs/mOyTSR4yPsaZ72a/MtuK6RnC3JYqWONe48oLaoEcYwEDxqvbXz85G4SJrm2Z5Ar9zp6MiHF4AlFlRM4Pg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-util": "^29.6.3"
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6107,17 +6399,17 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.4.tgz",
-      "integrity": "sha512-fPRq+0vcxsuGlG0O3gyoqGTAxasagOxEuyoxHeyxaZbc9QNek0AmJWSkhjlMG+mTsj+8knc/mWb3fXlRNVih7Q==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.4",
+        "jest-haste-map": "^29.7.0",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.6.3",
-        "jest-validate": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
         "resolve": "^1.20.0",
         "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
@@ -6127,43 +6419,43 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.4.tgz",
-      "integrity": "sha512-7+6eAmr1ZBF3vOAJVsfLj1QdqeXG+WYhidfLHBRZqGN24MFRIiKG20ItpLw2qRAsW/D2ZUUmCNf6irUr/v6KHA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
       "dev": true,
       "dependencies": {
         "jest-regex-util": "^29.6.3",
-        "jest-snapshot": "^29.6.4"
+        "jest-snapshot": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.4.tgz",
-      "integrity": "sha512-SDaLrMmtVlQYDuG0iSPYLycG8P9jLI+fRm8AF/xPKhYDB2g6xDWjXBrR5M8gEWsK6KVFlebpZ4QsrxdyIX1Jaw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.4",
-        "@jest/environment": "^29.6.4",
-        "@jest/test-result": "^29.6.4",
-        "@jest/transform": "^29.6.4",
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
-        "jest-docblock": "^29.6.3",
-        "jest-environment-node": "^29.6.4",
-        "jest-haste-map": "^29.6.4",
-        "jest-leak-detector": "^29.6.3",
-        "jest-message-util": "^29.6.3",
-        "jest-resolve": "^29.6.4",
-        "jest-runtime": "^29.6.4",
-        "jest-util": "^29.6.3",
-        "jest-watcher": "^29.6.4",
-        "jest-worker": "^29.6.4",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -6172,17 +6464,17 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.4.tgz",
-      "integrity": "sha512-s/QxMBLvmwLdchKEjcLfwzP7h+jsHvNEtxGP5P+Fl1FMaJX2jMiIqe4rJw4tFprzCwuSvVUo9bn0uj4gNRXsbA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.4",
-        "@jest/fake-timers": "^29.6.4",
-        "@jest/globals": "^29.6.4",
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
         "@jest/source-map": "^29.6.3",
-        "@jest/test-result": "^29.6.4",
-        "@jest/transform": "^29.6.4",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -6190,13 +6482,13 @@
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.4",
-        "jest-message-util": "^29.6.3",
-        "jest-mock": "^29.6.3",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
         "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.6.4",
-        "jest-snapshot": "^29.6.4",
-        "jest-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -6205,9 +6497,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.4.tgz",
-      "integrity": "sha512-VC1N8ED7+4uboUKGIDsbvNAZb6LakgIPgAF4RSpF13dN6YaMokfRqO+BaqK4zIh6X3JffgwbzuGqDEjHm/MrvA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -6215,20 +6507,20 @@
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.6.4",
-        "@jest/transform": "^29.6.4",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.6.4",
+        "expect": "^29.7.0",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.6.4",
+        "jest-diff": "^29.7.0",
         "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.6.4",
-        "jest-message-util": "^29.6.3",
-        "jest-util": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.6.3",
+        "pretty-format": "^29.7.0",
         "semver": "^7.5.3"
       },
       "engines": {
@@ -6236,9 +6528,9 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.3.tgz",
-      "integrity": "sha512-QUjna/xSy4B32fzcKTSz1w7YYzgiHrjjJjevdRf61HYk998R5vVMMNmrHESYZVDS5DSWs+1srPLPKxXPkeSDOA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -6253,9 +6545,9 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.6.3.tgz",
-      "integrity": "sha512-e7KWZcAIX+2W1o3cHfnqpGajdCs1jSM3DkXjGeLSNmCazv1EeI1ggTeK5wdZhF+7N+g44JI2Od3veojoaumlfg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -6263,7 +6555,7 @@
         "chalk": "^4.0.0",
         "jest-get-type": "^29.6.3",
         "leven": "^3.1.0",
-        "pretty-format": "^29.6.3"
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6282,18 +6574,18 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.4.tgz",
-      "integrity": "sha512-oqUWvx6+On04ShsT00Ir9T4/FvBeEh2M9PTubgITPxDa739p4hoQweWPRGyYeaojgT0xTpZKF0Y/rSY1UgMxvQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.6.4",
+        "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
-        "jest-util": "^29.6.3",
+        "jest-util": "^29.7.0",
         "string-length": "^4.0.1"
       },
       "engines": {
@@ -6301,13 +6593,13 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "29.6.4",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.4.tgz",
-      "integrity": "sha512-6dpvFV4WjcWbDVGgHTWo/aupl8/LbBx2NSKfiwqf79xC/yeJjKHT1+StcKy/2KTmW16hE68ccKVOtXf+WZGz7Q==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.6.3",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -6435,9 +6727,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
-      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -6520,6 +6812,26 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6527,6 +6839,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "dependencies": {
+        "es5-ext": "~0.10.2"
       }
     },
     "node_modules/make-dir": {
@@ -6557,6 +6877,21 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/memoizee": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.53",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
       }
     },
     "node_modules/merge-stream": {
@@ -6618,7 +6953,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6647,6 +6981,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -6710,15 +7049,16 @@
       }
     },
     "node_modules/open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6754,6 +7094,28 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/os-homedir": {
@@ -6989,9 +7351,9 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.3.tgz",
-      "integrity": "sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -7041,9 +7403,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
-      "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
       "dev": true,
       "funding": [
         {
@@ -7096,11 +7458,32 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7111,9 +7494,9 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
-      "version": "1.22.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
-      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "version": "1.22.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
+      "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
       "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -7235,20 +7618,31 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
     },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -7275,7 +7669,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7290,7 +7683,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -7301,8 +7693,7 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/sha1": {
       "version": "1.1.1",
@@ -7357,6 +7748,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7400,6 +7807,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -7505,6 +7920,41 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
+    "node_modules/table": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -7537,6 +7987,15 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "dependencies": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -7602,9 +8061,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
-      "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+      "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
       "dev": true,
       "engines": {
         "node": ">=16.13.0"
@@ -7713,6 +8172,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
+    "node_modules/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7768,9 +8232,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dev": true,
       "funding": [
         {
@@ -7801,7 +8265,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -7841,6 +8304,11 @@
         "which-typed-array": "^1.1.2"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -7860,24 +8328,18 @@
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
-      "integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
+      "integrity": "sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^1.6.0"
+        "convert-source-map": "^2.0.0"
       },
       "engines": {
         "node": ">=10.12.0"
       }
-    },
-    "node_modules/v8-to-istanbul/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -7918,6 +8380,14 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/webidl-conversions": {
@@ -8022,6 +8492,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-firewall-factory",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "bin": {
     "firewallfactory": "bin/aws-firewall-factory.js"
   },
@@ -9,14 +9,13 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
-    "lint": "eslint --ext .js,.ts ."
+    "lint": "eslint --ext .ts ."
   },
   "devDependencies": {
     "@types/node": "18.16.3",
-    "@types/uuid": "^9.0.4",
-    "@typescript-eslint/eslint-plugin": "6.4.1",
+    "@typescript-eslint/eslint-plugin": "6.7.4",
     "@typescript-eslint/parser": "6.0.0",
-    "aws-cdk": "^2.93.0",
+    "aws-cdk": "2.100.0",
     "eslint": "8.48.0",
     "jest": "29.5.0",
     "ts-jest": "29.1.1",
@@ -24,21 +23,23 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@aws-sdk/client-cloudformation": "^3.398.0",
-    "@aws-sdk/client-cloudwatch": "^3.398.0",
-    "@aws-sdk/client-fms": "^3.398.0",
-    "@aws-sdk/client-pricing": "^3.398.0",
-    "@aws-sdk/client-service-quotas": "^3.398.0",
-    "@aws-sdk/client-shield": "^3.398.0",
-    "@aws-sdk/client-wafv2": "^3.398.0",
+    "@aws-sdk/client-cloudformation": "^3.427.0",
+    "@aws-sdk/client-cloudwatch": "^3.427.0",
+    "@aws-sdk/client-fms": "^3.427.0",
+    "@aws-sdk/client-pricing": "^3.427.0",
+    "@aws-sdk/client-service-quotas": "^3.427.0",
+    "@aws-sdk/client-shield": "^3.427.0",
+    "@aws-sdk/client-wafv2": "^3.427.0",
     "@mhlabs/cfn-diagram": "^1.1.29",
     "@types/aws-lambda": "^8.10.119",
     "@types/lodash": "4.14.178",
-    "aws-cdk-lib": "2.93.0",
+    "@types/uuid": "^9.0.5",
+    "aws-cdk-lib": "2.100.0",
     "aws-lambda": "^1.0.7",
     "cfonts": "^3.2.0",
     "constructs": "10.2.25",
     "lodash": "4.17.21",
+    "table": "^6.8.1",
     "uuid": "^9.0.1"
   }
 }


### PR DESCRIPTION
### Added
- Added Console output if ManagedRuleGroup OverrideAction is set to Count - This option is not commonly used. If any rule in the rule group results in a match, this override sets the resulting action from the rule group to Count.
- Enums for all AWS ManagedRuleGroup Rules and Labels, this will help you to not create exclude Rules of Label Match Statements for none existing Rules or Labels. AWS CloudFormation even not trow any error right now if you try use not existing Labels or Rules.
- Optional Lambda function to prerequisite Stack that sends notifications about changes in AWS managed rule groups, such as upcoming new versions and urgent security updates, to messaging platforms like Slack or Teams.
### Fixed
- RegexPatternSets and IPSets in NotStatements AWS Firewall Factory are ignored while WCU calculation
- gotestwaf task was not customized for Typescript configuration files.
- ManagedRuleGroupVersion lambda was always using the latest ManagedRulegroup version if no version was specified. Now the lambda function is using the [current Default version](https://docs.aws.amazon.com/waf/latest/developerguide/waf-managed-rule-groups-versioning.html).
- Added Optional Parameter for ManagedRuleGroupVersion lambda, you can now set enforceUpdate to load the latest or the current Default version during WAF update.
- Bump @aws-cdk-lib from 2.93.0 to 2.100.0
- Bump @aws-cdk from 2.93.0 to 2.100.0
- Bump @aws-sdk/client-cloudformation from 3.398.0 to 3.427.0
- Bump @aws-sdk/client-cloudwatch from 3.398.0 to 3.427.0
- Bump @aws-sdk/client-fms from 3.398.0 to 3.427.0
- Bump @aws-sdk/client-pricing from 3.398.0 to 3.427.0
- Bump @aws-sdk/client-service-quotas from 3.398.0 to 3.427.0
- Bump @aws-sdk/client-shield from 3.398.0 to 3.427.0
- Bump @aws-sdk/client-wafv2 from 3.398.0 to 3.427.0
- Bump @typescript-eslint/eslint-plugin from 6.4.1 to 6.7.4