### PR TITLE
4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Released
 
+## 4.2.1
+### Fixed
+- [Issue285](https://github.com/globaldatanet/aws-firewall-factory/issues/285) - Resolved an issue where the redeployment of changed capacity was not functioning correctly due to inconsistencies in the writing of ProcessProperties for DeployedRuleGroups.
+- Bump ts-jest from 29.1.1 to 29.1.2
+- Bump @aws-sdk/client-wafv2 from 3.490.0 to 3.496.0
+- Bump @aws-sdk/client-service-quotas from 3.490.0 to 3.496.0
+- Bump @types/node from 20.11.4 to 20.11.5
+- Bump @aws-sdk/client-pricing from 3.490.0 to 3.496.0
+
 ## 4.2.0
 ### Fixed
 - Output of the correct ManagedRuleGroup version if the stack has already been deployed, no version has been specifically set or Enforce Update has been set

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "aws-firewall-factory",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-firewall-factory",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.490.0",
         "@aws-sdk/client-cloudwatch": "^3.490.0",
         "@aws-sdk/client-fms": "^3.490.0",
-        "@aws-sdk/client-pricing": "^3.490.0",
-        "@aws-sdk/client-service-quotas": "^3.490.0",
+        "@aws-sdk/client-pricing": "^3.496.0",
+        "@aws-sdk/client-service-quotas": "^3.496.0",
         "@aws-sdk/client-shield": "^3.490.0",
-        "@aws-sdk/client-wafv2": "^3.490.0",
+        "@aws-sdk/client-wafv2": "^3.496.0",
         "@babel/traverse": "^7.23.7",
         "@mhlabs/cfn-diagram": "^1.1.38",
         "@slack/types": "^2.11.0",
@@ -38,13 +38,13 @@
         "firewallfactory": "bin/aws-firewall-factory.js"
       },
       "devDependencies": {
-        "@types/node": "20.11.4",
+        "@types/node": "20.11.5",
         "@typescript-eslint/eslint-plugin": "6.19.0",
         "@typescript-eslint/parser": "6.19.0",
         "aws-cdk": "2.121.1",
         "eslint": "8.56.0",
         "jest": "29.7.0",
-        "ts-jest": "29.1.1",
+        "ts-jest": "29.1.2",
         "ts-node": "10.9.2",
         "typescript": "5.3.3"
       }
@@ -383,103 +383,963 @@
       }
     },
     "node_modules/@aws-sdk/client-pricing": {
-      "version": "3.490.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-pricing/-/client-pricing-3.490.0.tgz",
-      "integrity": "sha512-GqK/aqYpCcAR6qPBbS454Hz8azvS0fryCgwIbe5tQDM4YzSNTqnI+zrLi6v6HFQUkZZZNqfOKL7XMaoLAQRRUQ==",
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-pricing/-/client-pricing-3.496.0.tgz",
+      "integrity": "sha512-9vAWQzl9UiBmgKpuVfw7oZv11/cJc+tmFQiRpDZpUh9JQkfRss6ttxu4nxhg1a6YNDE514H/Nc8bKO7/9s6kTA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.490.0",
-        "@aws-sdk/core": "3.490.0",
-        "@aws-sdk/credential-provider-node": "3.490.0",
-        "@aws-sdk/middleware-host-header": "3.489.0",
-        "@aws-sdk/middleware-logger": "3.489.0",
-        "@aws-sdk/middleware-recursion-detection": "3.489.0",
-        "@aws-sdk/middleware-signing": "3.489.0",
-        "@aws-sdk/middleware-user-agent": "3.489.0",
-        "@aws-sdk/region-config-resolver": "3.489.0",
-        "@aws-sdk/types": "3.489.0",
-        "@aws-sdk/util-endpoints": "3.489.0",
-        "@aws-sdk/util-user-agent-browser": "3.489.0",
-        "@aws-sdk/util-user-agent-node": "3.489.0",
-        "@smithy/config-resolver": "^2.0.23",
-        "@smithy/core": "^1.2.2",
-        "@smithy/fetch-http-handler": "^2.3.2",
-        "@smithy/hash-node": "^2.0.18",
-        "@smithy/invalid-dependency": "^2.0.16",
-        "@smithy/middleware-content-length": "^2.0.18",
-        "@smithy/middleware-endpoint": "^2.3.0",
-        "@smithy/middleware-retry": "^2.0.26",
-        "@smithy/middleware-serde": "^2.0.16",
-        "@smithy/middleware-stack": "^2.0.10",
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/node-http-handler": "^2.2.2",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
-        "@smithy/url-parser": "^2.0.16",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-body-length-browser": "^2.0.1",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.24",
-        "@smithy/util-defaults-mode-node": "^2.0.32",
-        "@smithy/util-endpoints": "^1.0.8",
-        "@smithy/util-retry": "^2.0.9",
-        "@smithy/util-utf8": "^2.0.2",
+        "@aws-sdk/client-sts": "3.496.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/credential-provider-node": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-signing": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-service-quotas": {
-      "version": "3.490.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-service-quotas/-/client-service-quotas-3.490.0.tgz",
-      "integrity": "sha512-FKu+iaJYUaNa2hsJNBg9wnWkLXnnIPEvaYOt4dmvNLz2paSlLJm2bJeIiVUeyNa3AH9iqaelP+p1mc0za+wtOQ==",
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/client-sso": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.490.0",
-        "@aws-sdk/core": "3.490.0",
-        "@aws-sdk/credential-provider-node": "3.490.0",
-        "@aws-sdk/middleware-host-header": "3.489.0",
-        "@aws-sdk/middleware-logger": "3.489.0",
-        "@aws-sdk/middleware-recursion-detection": "3.489.0",
-        "@aws-sdk/middleware-signing": "3.489.0",
-        "@aws-sdk/middleware-user-agent": "3.489.0",
-        "@aws-sdk/region-config-resolver": "3.489.0",
-        "@aws-sdk/types": "3.489.0",
-        "@aws-sdk/util-endpoints": "3.489.0",
-        "@aws-sdk/util-user-agent-browser": "3.489.0",
-        "@aws-sdk/util-user-agent-node": "3.489.0",
-        "@smithy/config-resolver": "^2.0.23",
-        "@smithy/core": "^1.2.2",
-        "@smithy/fetch-http-handler": "^2.3.2",
-        "@smithy/hash-node": "^2.0.18",
-        "@smithy/invalid-dependency": "^2.0.16",
-        "@smithy/middleware-content-length": "^2.0.18",
-        "@smithy/middleware-endpoint": "^2.3.0",
-        "@smithy/middleware-retry": "^2.0.26",
-        "@smithy/middleware-serde": "^2.0.16",
-        "@smithy/middleware-stack": "^2.0.10",
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/node-http-handler": "^2.2.2",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
-        "@smithy/url-parser": "^2.0.16",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-body-length-browser": "^2.0.1",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.24",
-        "@smithy/util-defaults-mode-node": "^2.0.32",
-        "@smithy/util-endpoints": "^1.0.8",
-        "@smithy/util-retry": "^2.0.9",
-        "@smithy/util-utf8": "^2.0.2",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/client-sts": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.496.0.tgz",
+      "integrity": "sha512-3pSdqgegdwbK3CT1WvGHhA+Bf91R9cr8G1Ynp+iU2wZvy8ueJfMUk0NYfjo3EEv0YhSbMLKuduzZfvQHFHXYhw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/credential-provider-node": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/core": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
+      "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
+      "dependencies": {
+        "@smithy/core": "^1.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.496.0",
+        "@aws-sdk/credential-provider-process": "3.496.0",
+        "@aws-sdk/credential-provider-sso": "3.496.0",
+        "@aws-sdk/credential-provider-web-identity": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.496.0",
+        "@aws-sdk/credential-provider-ini": "3.496.0",
+        "@aws-sdk/credential-provider-process": "3.496.0",
+        "@aws-sdk/credential-provider-sso": "3.496.0",
+        "@aws-sdk/credential-provider-web-identity": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.496.0",
+        "@aws-sdk/token-providers": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+      "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/token-providers": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-pricing/node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-service-quotas/-/client-service-quotas-3.496.0.tgz",
+      "integrity": "sha512-/DCHElWA1fnVD0LCMt2msLIxs/DuowhHeIoiCtBiRfTQiZXbZvHFy5YLd58pIV35al3gKbuu2Yw9NY4I2rDftg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.496.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/credential-provider-node": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-signing": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/client-sso": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/client-sts": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.496.0.tgz",
+      "integrity": "sha512-3pSdqgegdwbK3CT1WvGHhA+Bf91R9cr8G1Ynp+iU2wZvy8ueJfMUk0NYfjo3EEv0YhSbMLKuduzZfvQHFHXYhw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/credential-provider-node": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/core": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
+      "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
+      "dependencies": {
+        "@smithy/core": "^1.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.496.0",
+        "@aws-sdk/credential-provider-process": "3.496.0",
+        "@aws-sdk/credential-provider-sso": "3.496.0",
+        "@aws-sdk/credential-provider-web-identity": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.496.0",
+        "@aws-sdk/credential-provider-ini": "3.496.0",
+        "@aws-sdk/credential-provider-process": "3.496.0",
+        "@aws-sdk/credential-provider-sso": "3.496.0",
+        "@aws-sdk/credential-provider-web-identity": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.496.0",
+        "@aws-sdk/token-providers": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+      "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/token-providers": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-service-quotas/node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/client-shield": {
@@ -651,52 +1511,482 @@
       }
     },
     "node_modules/@aws-sdk/client-wafv2": {
-      "version": "3.490.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-wafv2/-/client-wafv2-3.490.0.tgz",
-      "integrity": "sha512-aParttJSngBywgmKlNtebECWyyml80mwpAwu/ZM5yXYpkIj6s02gloXcsEj3LrhNnHpcTwsKBfwHImJdTPONwg==",
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-wafv2/-/client-wafv2-3.496.0.tgz",
+      "integrity": "sha512-Tjg/8pvacWCr2Bn5vzp/40sqUkDzH844qP+PXhb+KTkGzOb3rbynJUSOhYTBQ2gmNOqsjxE+0hZ679mWvR5QKA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.490.0",
-        "@aws-sdk/core": "3.490.0",
-        "@aws-sdk/credential-provider-node": "3.490.0",
-        "@aws-sdk/middleware-host-header": "3.489.0",
-        "@aws-sdk/middleware-logger": "3.489.0",
-        "@aws-sdk/middleware-recursion-detection": "3.489.0",
-        "@aws-sdk/middleware-signing": "3.489.0",
-        "@aws-sdk/middleware-user-agent": "3.489.0",
-        "@aws-sdk/region-config-resolver": "3.489.0",
-        "@aws-sdk/types": "3.489.0",
-        "@aws-sdk/util-endpoints": "3.489.0",
-        "@aws-sdk/util-user-agent-browser": "3.489.0",
-        "@aws-sdk/util-user-agent-node": "3.489.0",
-        "@smithy/config-resolver": "^2.0.23",
-        "@smithy/fetch-http-handler": "^2.3.2",
-        "@smithy/hash-node": "^2.0.18",
-        "@smithy/invalid-dependency": "^2.0.16",
-        "@smithy/middleware-content-length": "^2.0.18",
-        "@smithy/middleware-endpoint": "^2.3.0",
-        "@smithy/middleware-retry": "^2.0.26",
-        "@smithy/middleware-serde": "^2.0.16",
-        "@smithy/middleware-stack": "^2.0.10",
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/node-http-handler": "^2.2.2",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
-        "@smithy/url-parser": "^2.0.16",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-body-length-browser": "^2.0.1",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.24",
-        "@smithy/util-defaults-mode-node": "^2.0.32",
-        "@smithy/util-endpoints": "^1.0.8",
-        "@smithy/util-retry": "^2.0.9",
-        "@smithy/util-utf8": "^2.0.2",
+        "@aws-sdk/client-sts": "3.496.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/credential-provider-node": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-signing": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/client-sso": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/client-sts": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.496.0.tgz",
+      "integrity": "sha512-3pSdqgegdwbK3CT1WvGHhA+Bf91R9cr8G1Ynp+iU2wZvy8ueJfMUk0NYfjo3EEv0YhSbMLKuduzZfvQHFHXYhw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/credential-provider-node": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/core": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
+      "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
+      "dependencies": {
+        "@smithy/core": "^1.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.496.0",
+        "@aws-sdk/credential-provider-process": "3.496.0",
+        "@aws-sdk/credential-provider-sso": "3.496.0",
+        "@aws-sdk/credential-provider-web-identity": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.496.0",
+        "@aws-sdk/credential-provider-ini": "3.496.0",
+        "@aws-sdk/credential-provider-process": "3.496.0",
+        "@aws-sdk/credential-provider-sso": "3.496.0",
+        "@aws-sdk/credential-provider-web-identity": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.496.0",
+        "@aws-sdk/token-providers": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+      "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/token-providers": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-wafv2/node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/core": {
@@ -2297,11 +3587,11 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.16.tgz",
-      "integrity": "sha512-4foO7738k8kM9flMHu3VLabqu7nPgvIj8TB909S0CnKx0YZz/dcDH3pZ/4JHdatfxlZdKF1JWOYCw9+v3HVVsw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+      "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2309,14 +3599,14 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.23.tgz",
-      "integrity": "sha512-XakUqgtP2YY8Mi+Nlif5BiqJgWdvfxJafSpOSQeCOMizu+PUhE4fBQSy6xFcR+eInrwVadaABNxoJyGUMn15ew==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+      "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-config-provider": "^2.1.0",
-        "@smithy/util-middleware": "^2.0.9",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2324,17 +3614,17 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.2.2.tgz",
-      "integrity": "sha512-uLjrskLT+mWb0emTR5QaiAIxVEU7ndpptDaVDrTwwhD+RjvHhjIiGQ3YL5jKk1a5VSDQUA2RGkXvJ6XKRcz6Dg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-tf+NIu9FkOh312b6M9G4D68is4Xr7qptzaZGZUREELF8ysE1yLKphqt7nsomjKZVwW7WE5pDDex9idowNGRQ/Q==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.3.0",
-        "@smithy/middleware-retry": "^2.0.26",
-        "@smithy/middleware-serde": "^2.0.16",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-middleware": "^2.0.9",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2342,14 +3632,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.5.tgz",
-      "integrity": "sha512-VfvE6Wg1MUWwpTZFBnUD7zxvPhLY8jlHCzu6bCjlIYoWgXCDzZAML76IlZUEf45nib3rjehnFgg0s1rgsuN/bg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+      "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/property-provider": "^2.0.17",
-        "@smithy/types": "^2.8.0",
-        "@smithy/url-parser": "^2.0.16",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2357,36 +3647,36 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.11.tgz",
-      "integrity": "sha512-BQCTjxhCYRZIfXapa2LmZSaH8QUBGwMZw7XRN83hrdixbLjIcj+o549zjkedFS07Ve2TlvWUI6BTzP+nv7snBA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+      "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.3.2.tgz",
-      "integrity": "sha512-O9R/OlnAOTsnysuSDjt0v2q6DcSvCz5cCFC/CFAWWcLyBwJDeFyGTCTszgpQTb19+Fi8uRwZE5/3ziAQBFeDMQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+      "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/querystring-builder": "^2.0.16",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-base64": "^2.0.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.18.tgz",
-      "integrity": "sha512-gN2JFvAgnZCyDN9rJgcejfpK0uPPJrSortVVVVWsru9whS7eQey6+gj2eM5ln2i6rHNntIXzal1Fm9XOPuoaKA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+      "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2394,18 +3684,18 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.16.tgz",
-      "integrity": "sha512-apEHakT/kmpNo1VFHP4W/cjfeP9U0x5qvfsLJubgp7UM/gq4qYp0GbqdE7QhsjUaYvEnrftRqs7+YrtWreV0wA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+      "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+      "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2414,12 +3704,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.18.tgz",
-      "integrity": "sha512-ZJ9uKPTfxYheTKSKYB+GCvcj+izw9WGzRLhjn8n254q0jWLojUzn7Vw0l4R/Gq7Wdpf/qmk/ptD+6CCXHNVCaw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+      "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/types": "^2.8.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2427,16 +3717,16 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.3.0.tgz",
-      "integrity": "sha512-VsOAG2YQ8ykjSmKO+CIXdJBIWFo6AAvG6Iw95BakBTqk66/4BI7XyqLevoNSq/lZ6NgZv24sLmrcIN+fLDWBCg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+      "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.16",
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/shared-ini-file-loader": "^2.2.8",
-        "@smithy/types": "^2.8.0",
-        "@smithy/url-parser": "^2.0.16",
-        "@smithy/util-middleware": "^2.0.9",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2444,17 +3734,17 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.26.tgz",
-      "integrity": "sha512-Qzpxo0U5jfNiq9iD38U3e2bheXwvTEX4eue9xruIvEgh+UKq6dKuGqcB66oBDV7TD/mfoJi9Q/VmaiqwWbEp7A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+      "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/service-error-classification": "^2.0.9",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-middleware": "^2.0.9",
-        "@smithy/util-retry": "^2.0.9",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -2471,11 +3761,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.16.tgz",
-      "integrity": "sha512-5EAd4t30pcc4M8TSSGq7q/x5IKrxfXR5+SrU4bgxNy7RPHQo2PSWBUco9C+D9Tfqp/JZvprRpK42dnupZafk2g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+      "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2483,11 +3773,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.10.tgz",
-      "integrity": "sha512-I2rbxctNq9FAPPEcuA1ntZxkTKOPQFy7YBPOaD/MLg1zCvzv21CoNxR0py6J8ZVC35l4qE4nhxB0f7TF5/+Ldw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+      "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2495,13 +3785,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.9.tgz",
-      "integrity": "sha512-tUyW/9xrRy+s7RXkmQhgYkAPMpTIF8izK4orhHjNFEKR3QZiOCbWB546Y8iB/Fpbm3O9+q0Af9rpywLKJOwtaQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+      "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.17",
-        "@smithy/shared-ini-file-loader": "^2.2.8",
-        "@smithy/types": "^2.8.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2509,14 +3799,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.2.2.tgz",
-      "integrity": "sha512-XO58TO/Eul/IBQKFKaaBtXJi0ItEQQCT+NI4IiKHCY/4KtqaUT6y/wC1EvDqlA9cP7Dyjdj7FdPs4DyynH3u7g==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+      "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.16",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/querystring-builder": "^2.0.16",
-        "@smithy/types": "^2.8.0",
+        "@smithy/abort-controller": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2524,11 +3814,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.17.tgz",
-      "integrity": "sha512-+VkeZbVu7qtQ2DjI48Qwaf9fPOr3gZIwxQpuLJgRRSkWsdSvmaTCxI3gzRFKePB63Ts9r4yjn4HkxSCSkdWmcQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+      "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2536,11 +3826,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.12.tgz",
-      "integrity": "sha512-Xz4iaqLiaBfbQpB9Hgi3VcZYbP7xRDXYhd8XWChh4v94uw7qwmvlxdU5yxzfm6ACJM66phHrTbS5TVvj5uQ72w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+      "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2548,12 +3838,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.16.tgz",
-      "integrity": "sha512-Q/GsJT0C0mijXMRs7YhZLLCP5FcuC4797lYjKQkME5CZohnLC4bEhylAd2QcD3gbMKNjCw8+T2I27WKiV/wToA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+      "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-uri-escape": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2561,11 +3851,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.16.tgz",
-      "integrity": "sha512-c4ueAuL6BDYKWpkubjrQthZKoC3L5kql5O++ovekNxiexRXTlLIVlCR4q3KziOktLIw66EU9SQljPXd/oN6Okg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+      "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2573,22 +3863,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.9.tgz",
-      "integrity": "sha512-0K+8GvtwI7VkGmmInPydM2XZyBfIqLIbfR7mDQ+oPiz8mIinuHbV6sxOLdvX1Jv/myk7XTK9orgt3tuEpBu/zg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+      "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
       "dependencies": {
-        "@smithy/types": "^2.8.0"
+        "@smithy/types": "^2.9.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.8.tgz",
-      "integrity": "sha512-E62byatbwSWrtq9RJ7xN40tqrRKDGrEL4EluyNpaIDvfvet06a/QC58oHw2FgVaEgkj0tXZPjZaKrhPfpoU0qw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+      "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2596,17 +3886,17 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.11.tgz",
-      "integrity": "sha512-EFVU1dT+2s8xi227l1A9O27edT/GNKvyAK6lZnIZ0zhIHq/jSLznvkk15aonGAM1kmhmZBVGpI7Tt0odueZK9A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+      "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.11",
-        "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.4",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/eventstream-codec": "^2.1.1",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2614,15 +3904,15 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.2.1.tgz",
-      "integrity": "sha512-SpD7FLK92XV2fon2hMotaNDa2w5VAy5/uVjP9WFmjGSgWM8pTPVkHcDl1yFs5Z8LYbij0FSz+DbCBK6i+uXXUA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+      "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.3.0",
-        "@smithy/middleware-stack": "^2.0.10",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-stream": "^2.0.24",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2630,9 +3920,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.8.0.tgz",
-      "integrity": "sha512-h9sz24cFgt/W1Re22OlhQKmUZkNh244ApgRsUDYinqF8R+QgcsBIX344u2j61TPshsTz3CvL6HYU1DnQdsSrHA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2641,21 +3931,21 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.16.tgz",
-      "integrity": "sha512-Wfz5WqAoRT91TjRy1JeLR0fXtkIXHGsMbgzKFTx7E68SrZ55TB8xoG+vm11Ru4gheFTMXjAjwAxv1jQdC+pAQA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+      "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.16",
-        "@smithy/types": "^2.8.0",
+        "@smithy/querystring-parser": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
-      "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+      "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2663,17 +3953,17 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.1.tgz",
-      "integrity": "sha512-NXYp3ttgUlwkaug4bjBzJ5+yIbUbUx8VsSLuHZROQpoik+gRkIBeEG9MPVYfvPNpuXb/puqodeeUXcKFe7BLOQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+      "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
       "dependencies": {
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+      "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2682,11 +3972,11 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+      "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/is-array-buffer": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2694,9 +3984,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.1.0.tgz",
-      "integrity": "sha512-S6V0JvvhQgFSGLcJeT1CBsaTR03MM8qTuxMH9WPCCddlSo2W0V5jIHimHtIQALMLEDPGQ0ROSRr/dU0O+mxiQg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+      "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2705,13 +3995,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.24.tgz",
-      "integrity": "sha512-TsP5mBuLgO2C21+laNG2nHYZEyUdkbGURv2tHvSuQQxLz952MegX95uwdxOY2jR2H4GoKuVRfdJq7w4eIjGYeg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+      "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.17",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -2720,16 +4010,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.32",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.32.tgz",
-      "integrity": "sha512-d0S33dXA2cq1NyorVMroMrEtqKMr3MlyLITcfTBf9pXiigYiPMOtbSI7czHIfDbuVuM89Cg0urAgpt73QV9mPQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.1.1.tgz",
+      "integrity": "sha512-tYVrc+w+jSBfBd267KDnvSGOh4NMz+wVH7v4CClDbkdPfnjvImBZsOURncT5jsFwR9KCuDyPoSZq4Pa6+eCUrA==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.23",
-        "@smithy/credential-provider-imds": "^2.1.5",
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/property-provider": "^2.0.17",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2737,12 +4027,12 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.8.tgz",
-      "integrity": "sha512-l8zVuyZZ61IzZBYp5NWvsAhbaAjYkt0xg9R4xUASkg5SEeTT2meHOJwJHctKMFUXe4QZbn9fR2MaBYjP2119+w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+      "integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/types": "^2.8.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2750,9 +4040,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+      "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2761,11 +4051,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.9.tgz",
-      "integrity": "sha512-PnCnBJ07noMX1lMDTEefmxSlusWJUiLfrme++MfK5TD0xz8NYmakgoXy5zkF/16zKGmiwOeKAztWT/Vjk1KRIQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+      "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2773,12 +4063,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.9.tgz",
-      "integrity": "sha512-46BFWe9RqB6g7f4mxm3W3HlqknqQQmWHKlhoqSFZuGNuiDU5KqmpebMbvC3tjTlUkqn4xa2Z7s3Hwb0HNs5scw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+      "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.0.9",
-        "@smithy/types": "^2.8.0",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2786,17 +4076,17 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.24.tgz",
-      "integrity": "sha512-hRpbcRrOxDriMVmbya+Mv77VZVupxRAsfxVDKS54XuiURhdiwCUXJP0X1iJhHinuUf6n8pBF0MkG9C8VooMnWw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+      "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.3.2",
-        "@smithy/node-http-handler": "^2.2.2",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2804,9 +4094,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+      "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2815,11 +4105,11 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
-      "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+      "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2962,9 +4252,9 @@
       "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
     },
     "node_modules/@types/node": {
-      "version": "20.11.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.4.tgz",
-      "integrity": "sha512-6I0fMH8Aoy2lOejL3s4LhyIYX34DPwY8bl5xlNjBvUEk8OHrcuzsFt+Ied4LvJihbtXPM+8zUqdydfIti86v9g==",
+      "version": "20.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+      "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -8109,9 +9399,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
-      "integrity": "sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==",
+      "version": "29.1.2",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
+      "integrity": "sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
@@ -8127,7 +9417,7 @@
         "ts-jest": "cli.js"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^16.10.0 || ^18.0.0 || >=20.0.0"
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-firewall-factory",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "bin": {
     "firewallfactory": "bin/aws-firewall-factory.js"
   },
@@ -12,13 +12,13 @@
     "lint": "eslint --ext .ts ."
   },
   "devDependencies": {
-    "@types/node": "20.11.4",
+    "@types/node": "20.11.5",
     "@typescript-eslint/eslint-plugin": "6.19.0",
     "@typescript-eslint/parser": "6.19.0",
     "aws-cdk": "2.121.1",
     "eslint": "8.56.0",
     "jest": "29.7.0",
-    "ts-jest": "29.1.1",
+    "ts-jest": "29.1.2",
     "ts-node": "10.9.2",
     "typescript": "5.3.3"
   },
@@ -26,10 +26,10 @@
     "@aws-sdk/client-cloudformation": "^3.490.0",
     "@aws-sdk/client-cloudwatch": "^3.490.0",
     "@aws-sdk/client-fms": "^3.490.0",
-    "@aws-sdk/client-pricing": "^3.490.0",
-    "@aws-sdk/client-service-quotas": "^3.490.0",
+    "@aws-sdk/client-pricing": "^3.496.0",
+    "@aws-sdk/client-service-quotas": "^3.496.0",
     "@aws-sdk/client-shield": "^3.490.0",
-    "@aws-sdk/client-wafv2": "^3.490.0",
+    "@aws-sdk/client-wafv2": "^3.496.0",
     "@babel/traverse": "^7.23.7",
     "@mhlabs/cfn-diagram": "^1.1.38",
     "@slack/types": "^2.11.0",


### PR DESCRIPTION
### Fixed
- [Issue285](https://github.com/globaldatanet/aws-firewall-factory/issues/285) - Resolved an issue where the redeployment of changed capacity was not functioning correctly due to inconsistencies in the writing of ProcessProperties for DeployedRuleGroups.
- Bump ts-jest from 29.1.1 to 29.1.2
- Bump @aws-sdk/client-wafv2 from 3.490.0 to 3.496.0
- Bump @aws-sdk/client-service-quotas from 3.490.0 to 3.496.0
- Bump @types/node from 20.11.4 to 20.11.5
- Bump @aws-sdk/client-pricing from 3.490.0 to 3.496.0